### PR TITLE
Stop converting all names to uppercase.

### DIFF
--- a/LibHac.Nand/DiscUtils.Fat/ClusterStream.cs
+++ b/LibHac.Nand/DiscUtils.Fat/ClusterStream.cs
@@ -115,7 +115,7 @@ namespace DiscUtils.Fat
 
             if (_position > _length)
             {
-                throw new IOException("Attempt to read beyond end of file");
+                return 0;
             }
 
             if (count < 0)

--- a/LibHac.Nand/DiscUtils.Fat/Directory.cs
+++ b/LibHac.Nand/DiscUtils.Fat/Directory.cs
@@ -414,7 +414,7 @@ namespace DiscUtils.Fat
                                 validChecksum = false;
                                 break;
                             }
-                            sb.Append(slot.Name.ToUpperInvariant());
+                            sb.Append(slot.Name);
                         }
 
                         if (validChecksum)

--- a/LibHac/FileSystem.cs
+++ b/LibHac/FileSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace LibHac
 {
@@ -38,7 +39,29 @@ namespace LibHac
 
         public string[] GetFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
         {
-            return Directory.GetFileSystemEntries(Path.Combine(Root, path), searchPattern, searchOption);
+            //return Directory.GetFileSystemEntries(Path.Combine(Root, path), searchPattern, searchOption);
+            var result = new List<string>();
+
+            try
+            {
+                result.AddRange(GetFileSystemEntries(Path.Combine(Root, path), searchPattern));
+            }
+            catch { /**/ }
+
+            if (searchOption == SearchOption.TopDirectoryOnly)
+                return result.ToArray();
+
+            var searchDirectories = Directory.GetDirectories(Path.Combine(Root, path));
+            foreach (var search in searchDirectories)
+            {
+                try
+                {
+                    result.AddRange(GetFileSystemEntries(search, searchPattern, searchOption));
+                }
+                catch { /**/ }
+            }
+
+            return result.ToArray();
         }
 
         public string GetFullPath(string path)

--- a/LibHac/FileSystem.cs
+++ b/LibHac/FileSystem.cs
@@ -23,12 +23,12 @@ namespace LibHac
 
         public Stream OpenFile(string path, FileMode mode)
         {
-            return new FileStream(path, mode);
+            return new FileStream(Path.Combine(Root, path), mode);
         }
 
         public Stream OpenFile(string path, FileMode mode, FileAccess access)
         {
-            return new FileStream(path, mode, access);
+            return new FileStream(Path.Combine(Root, path), mode, access);
         }
 
         public string[] GetFileSystemEntries(string path, string searchPattern)

--- a/LibHac/FileSystem.cs
+++ b/LibHac/FileSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace LibHac
@@ -46,7 +47,7 @@ namespace LibHac
             {
                 result.AddRange(GetFileSystemEntries(Path.Combine(Root, path), searchPattern));
             }
-            catch { /**/ }
+            catch (UnauthorizedAccessException) { /* Skip this directory */ }
 
             if (searchOption == SearchOption.TopDirectoryOnly)
                 return result.ToArray();
@@ -58,7 +59,7 @@ namespace LibHac
                 {
                     result.AddRange(GetFileSystemEntries(search, searchPattern, searchOption));
                 }
-                catch { /**/ }
+                catch (UnauthorizedAccessException) { /* Skip this result */ }
             }
 
             return result.ToArray();

--- a/LibHac/Streams/CombinationStream.cs
+++ b/LibHac/Streams/CombinationStream.cs
@@ -126,6 +126,7 @@ namespace LibHac.Streams
                         break;
 
                     _currentStream = _streams[_currentStreamIndex++];
+                    _currentStream.Position = 0;
                 }
             }
 


### PR DESCRIPTION
I noticed that the fat library was always returing directory / file names that were ALL UPPERCASE.  Kind of annoying especially when I know that was NOT how the names were originally stored in the fat file system.