### PR TITLE
NCA and misc. improvements

### DIFF
--- a/LibHac/Bktr.cs
+++ b/LibHac/Bktr.cs
@@ -19,7 +19,7 @@ namespace LibHac
 
         public Bktr(Stream patchRomfs, Stream baseRomfs, NcaSection section)
         {
-            if (section.Type != SectionType.Bktr) throw new ArgumentException("Section is not of type BKTR");
+            if (section.Header.EncryptionType != NcaEncryptionType.AesCtrEx) throw new ArgumentException("Section is not of type BKTR");
             Patch = patchRomfs ?? throw new NullReferenceException($"{nameof(patchRomfs)} cannot be null");
             Base = baseRomfs ?? throw new NullReferenceException($"{nameof(baseRomfs)} cannot be null");
 

--- a/LibHac/BktrCryptoStream.cs
+++ b/LibHac/BktrCryptoStream.cs
@@ -78,8 +78,6 @@ namespace LibHac
                 int bytesToRead = (int)Math.Min(CurrentEntry.OffsetEnd - Position, count);
                 int bytesRead = base.Read(buffer, outPos, bytesToRead);
 
-                if (bytesRead == 0) break;
-
                 outPos += bytesRead;
                 totalBytesRead += bytesRead;
                 count -= bytesRead;
@@ -88,6 +86,10 @@ namespace LibHac
                 {
                     CurrentEntry = CurrentEntry.Next;
                     UpdateCounterSubsection(CurrentEntry.Counter);
+                }
+                else if (bytesRead == 0)
+                {
+                    break;
                 }
             }
 

--- a/LibHac/BktrCryptoStream.cs
+++ b/LibHac/BktrCryptoStream.cs
@@ -78,6 +78,8 @@ namespace LibHac
                 int bytesToRead = (int)Math.Min(CurrentEntry.OffsetEnd - Position, count);
                 int bytesRead = base.Read(buffer, outPos, bytesToRead);
 
+                if (bytesRead == 0) break;
+
                 outPos += bytesRead;
                 totalBytesRead += bytesRead;
                 count -= bytesRead;

--- a/LibHac/HierarchicalIntegrityVerificationStream.cs
+++ b/LibHac/HierarchicalIntegrityVerificationStream.cs
@@ -62,7 +62,7 @@ namespace LibHac
             {
                 if (validities[i] == Validity.Unchecked)
                 {
-                    levelStream.Position = levelStream.SectorSize * i;
+                    levelStream.Position = (long)levelStream.SectorSize * i;
                     levelStream.Read(buffer, 0, buffer.Length, IntegrityCheckLevel.IgnoreOnInvalid);
                 }
 

--- a/LibHac/HierarchicalIntegrityVerificationStream.cs
+++ b/LibHac/HierarchicalIntegrityVerificationStream.cs
@@ -8,18 +8,18 @@ namespace LibHac
     {
         public Stream[] Levels { get; }
         public Stream DataLevel { get; }
-        public bool EnableIntegrityChecks { get; }
+        public IntegrityCheckLevel IntegrityCheckLevel { get; }
 
-        public HierarchicalIntegrityVerificationStream(IntegrityVerificationInfo[] levelInfo, bool enableIntegrityChecks)
+        public HierarchicalIntegrityVerificationStream(IntegrityVerificationInfo[] levelInfo, IntegrityCheckLevel integrityCheckLevel)
         {
             Levels = new Stream[levelInfo.Length];
-            EnableIntegrityChecks = enableIntegrityChecks;
+            IntegrityCheckLevel = integrityCheckLevel;
 
             Levels[0] = levelInfo[0].Data;
 
             for (int i = 1; i < Levels.Length; i++)
             {
-                var levelData = new IntegrityVerificationStream(levelInfo[i], Levels[i - 1], enableIntegrityChecks);
+                var levelData = new IntegrityVerificationStream(levelInfo[i], Levels[i - 1], integrityCheckLevel);
 
                 Levels[i] = new RandomAccessSectorStream(levelData);
             }

--- a/LibHac/HierarchicalIntegrityVerificationStream.cs
+++ b/LibHac/HierarchicalIntegrityVerificationStream.cs
@@ -10,10 +10,19 @@ namespace LibHac
         public Stream DataLevel { get; }
         public IntegrityCheckLevel IntegrityCheckLevel { get; }
 
+        /// <summary>
+        /// An array of the hash statuses of every block in each level.
+        /// </summary>
+        public Validity[][] LevelValidities { get; }
+
+        private IntegrityVerificationStream[] IntegrityStreams { get; }
+
         public HierarchicalIntegrityVerificationStream(IntegrityVerificationInfo[] levelInfo, IntegrityCheckLevel integrityCheckLevel)
         {
             Levels = new Stream[levelInfo.Length];
             IntegrityCheckLevel = integrityCheckLevel;
+            LevelValidities = new Validity[levelInfo.Length - 1][];
+            IntegrityStreams = new IntegrityVerificationStream[levelInfo.Length - 1];
 
             Levels[0] = levelInfo[0].Data;
 
@@ -22,9 +31,53 @@ namespace LibHac
                 var levelData = new IntegrityVerificationStream(levelInfo[i], Levels[i - 1], integrityCheckLevel);
 
                 Levels[i] = new RandomAccessSectorStream(levelData);
+                LevelValidities[i - 1] = levelData.BlockValidities;
+                IntegrityStreams[i - 1] = levelData;
             }
 
             DataLevel = Levels[Levels.Length - 1];
+        }
+
+        /// <summary>
+        /// Checks the hashes of any unchecked blocks and returns the <see cref="Validity"/> of the hash level.
+        /// </summary>
+        /// <param name="level">The level of hierarchical hashes to check.</param>
+        /// <param name="returnOnError">If <see langword="true"/>, return as soon as an invalid block is found.</param>
+        /// <param name="logger">An optional <see cref="IProgressReport"/> for reporting progress.</param>
+        /// <returns>The <see cref="Validity"/> of the data of the specified hash level.</returns>
+        public Validity ValidateLevel(int level, bool returnOnError, IProgressReport logger = null)
+        {
+            Validity[] validities = LevelValidities[level];
+            IntegrityVerificationStream levelStream = IntegrityStreams[level];
+
+            // The original position of the stream must be restored when we're done validating
+            long initialPosition = levelStream.Position;
+
+            var buffer = new byte[levelStream.SectorSize];
+            var result = Validity.Valid;
+
+            logger?.SetTotal(levelStream.SectorCount);
+
+            for (int i = 0; i < levelStream.SectorCount; i++)
+            {
+                if (validities[i] == Validity.Unchecked)
+                {
+                    levelStream.Position = levelStream.SectorSize * i;
+                    levelStream.Read(buffer, 0, buffer.Length, IntegrityCheckLevel.IgnoreOnInvalid);
+                }
+
+                if (validities[i] == Validity.Invalid)
+                {
+                    result = Validity.Invalid;
+                    if (returnOnError) break;
+                }
+
+                logger?.ReportAdd(1);
+            }
+
+            logger?.SetTotal(0);
+            levelStream.Position = initialPosition;
+            return result;
         }
 
         public override void Flush()

--- a/LibHac/IntegrityVerificationStream.cs
+++ b/LibHac/IntegrityVerificationStream.cs
@@ -11,6 +11,7 @@ namespace LibHac
 
         private Stream HashStream { get; }
         public IntegrityCheckLevel IntegrityCheckLevel { get; }
+        public Validity[] BlockValidities { get; }
 
         private byte[] Salt { get; }
         private IntegrityStreamType Type { get; }
@@ -25,6 +26,8 @@ namespace LibHac
             IntegrityCheckLevel = integrityCheckLevel;
             Salt = info.Salt;
             Type = info.Type;
+
+            BlockValidities = new Validity[SectorCount];
         }
 
         public override void Flush()
@@ -55,12 +58,16 @@ namespace LibHac
             throw new NotImplementedException();
         }
 
-        public override int Read(byte[] buffer, int offset, int count)
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer, offset, count, IntegrityCheckLevel);
+
+        public int Read(byte[] buffer, int offset, int count, IntegrityCheckLevel integrityCheckLevel)
         {
-            HashStream.Position = CurrentSector * DigestSize;
+            long blockNum = CurrentSector;
+            HashStream.Position = blockNum * DigestSize;
             HashStream.Read(_hashBuffer, 0, DigestSize);
 
-            int bytesRead = base.Read(buffer, 0, count);
+            int bytesRead = base.Read(buffer, offset, count);
             int bytesToHash = SectorSize;
 
             if (bytesRead == 0) return 0;
@@ -68,14 +75,14 @@ namespace LibHac
             // If a hash is zero the data for the entire block is zero
             if (Type == IntegrityStreamType.Save && _hashBuffer.IsEmpty())
             {
-                Array.Clear(buffer, 0, SectorSize);
+                Array.Clear(buffer, offset, SectorSize);
                 return bytesRead;
             }
 
             if (bytesRead < SectorSize)
             {
                 // Pad out unused portion of block
-                Array.Clear(buffer, bytesRead, SectorSize - bytesRead);
+                Array.Clear(buffer, offset + bytesRead, SectorSize - bytesRead);
 
                 // Partition FS hashes don't pad out an incomplete block
                 if (Type == IntegrityStreamType.PartitionFs)
@@ -83,8 +90,15 @@ namespace LibHac
                     bytesToHash = bytesRead;
                 }
             }
+       
+            if (BlockValidities[blockNum] == Validity.Invalid && integrityCheckLevel == IntegrityCheckLevel.ErrorOnInvalid)
+            {
+                throw new InvalidDataException("Hash error!");
+            }
 
-            if (IntegrityCheckLevel == IntegrityCheckLevel.None) return bytesRead;
+            if (integrityCheckLevel == IntegrityCheckLevel.None) return bytesRead;
+
+            if (BlockValidities[blockNum] != Validity.Unchecked) return bytesRead;
 
             _hash.Initialize();
 
@@ -93,7 +107,7 @@ namespace LibHac
                 _hash.TransformBlock(Salt, 0, Salt.Length, null, 0);
             }
 
-            _hash.TransformBlock(buffer, 0, bytesToHash, null, 0);
+            _hash.TransformBlock(buffer, offset, bytesToHash, null, 0);
             _hash.TransformFinalBlock(buffer, 0, 0);
 
             byte[] hash = _hash.Hash;
@@ -104,7 +118,10 @@ namespace LibHac
                 hash[0x1F] |= 0x80;
             }
 
-            if (!Util.ArraysEqual(_hashBuffer, hash))
+            Validity validity = Util.ArraysEqual(_hashBuffer, hash) ? Validity.Valid : Validity.Invalid;
+            BlockValidities[blockNum] = validity;
+
+            if (validity == Validity.Invalid && integrityCheckLevel == IntegrityCheckLevel.ErrorOnInvalid)
             {
                 throw new InvalidDataException("Hash error!");
             }
@@ -150,9 +167,9 @@ namespace LibHac
         /// </summary>
         None,
         /// <summary>
-        /// 
+        /// Invalid blocks will be marked as invalid when read, and will not cause an error.
         /// </summary>
-        WarnOnInvalid,
+        IgnoreOnInvalid,
         /// <summary>
         /// An <see cref="InvalidDataException"/> will be thrown if an integrity check fails.
         /// </summary>

--- a/LibHac/IntegrityVerificationStream.cs
+++ b/LibHac/IntegrityVerificationStream.cs
@@ -10,7 +10,7 @@ namespace LibHac
         private const int DigestSize = 0x20;
 
         private Stream HashStream { get; }
-        public bool EnableIntegrityChecks { get; }
+        public IntegrityCheckLevel IntegrityCheckLevel { get; }
 
         private byte[] Salt { get; }
         private IntegrityStreamType Type { get; }
@@ -18,11 +18,11 @@ namespace LibHac
         private readonly byte[] _hashBuffer = new byte[DigestSize];
         private readonly SHA256 _hash = SHA256.Create();
 
-        public IntegrityVerificationStream(IntegrityVerificationInfo info, Stream hashStream, bool enableIntegrityChecks)
+        public IntegrityVerificationStream(IntegrityVerificationInfo info, Stream hashStream, IntegrityCheckLevel integrityCheckLevel)
             : base(info.Data, info.BlockSize)
         {
             HashStream = hashStream;
-            EnableIntegrityChecks = enableIntegrityChecks;
+            IntegrityCheckLevel = integrityCheckLevel;
             Salt = info.Salt;
             Type = info.Type;
         }
@@ -84,7 +84,7 @@ namespace LibHac
                 }
             }
 
-            if (!EnableIntegrityChecks) return bytesRead;
+            if (IntegrityCheckLevel == IntegrityCheckLevel.None) return bytesRead;
 
             _hash.Initialize();
 
@@ -138,5 +138,24 @@ namespace LibHac
         Save,
         RomFs,
         PartitionFs
+    }
+
+    /// <summary>
+    /// Represents the level of integrity checks to be performed.
+    /// </summary>
+    public enum IntegrityCheckLevel
+    {
+        /// <summary>
+        /// No integrity checks will be performed.
+        /// </summary>
+        None,
+        /// <summary>
+        /// 
+        /// </summary>
+        WarnOnInvalid,
+        /// <summary>
+        /// An <see cref="InvalidDataException"/> will be thrown if an integrity check fails.
+        /// </summary>
+        ErrorOnInvalid
     }
 }

--- a/LibHac/Keyset.cs
+++ b/LibHac/Keyset.cs
@@ -246,7 +246,7 @@ namespace LibHac
             Crypto.DecryptEcb(headerKek, HeaderKeySource, HeaderKey, 0x20);
         }
 
-        private void DeriveSdCardKeys()
+        public void DeriveSdCardKeys()
         {
             var sdKek = new byte[0x10];
             Crypto.GenerateKek(MasterKeys[0], SdCardKekSource, sdKek, AesKekGenerationSource, AesKeyGenerationSource);
@@ -264,6 +264,8 @@ namespace LibHac
                 Crypto.DecryptEcb(sdKek, SdCardKeySourcesSpecific[k], SdCardKeys[k], 0x20);
             }
         }
+
+        internal static readonly string[] KakNames = {"application", "ocean", "system"};
     }
 
     public static class ExternalKeys
@@ -396,7 +398,7 @@ namespace LibHac
 
         public static string PrintKeys(Keyset keyset, Dictionary<string, KeyValue> dict)
         {
-            if(dict.Count == 0) return string.Empty;
+            if (dict.Count == 0) return string.Empty;
 
             var sb = new StringBuilder();
             int maxNameLength = dict.Values.Max(x => x.Name.Length);

--- a/LibHac/Nca.cs
+++ b/LibHac/Nca.cs
@@ -140,8 +140,7 @@ namespace LibHac
                         false);
                     if (BaseNca == null) return rawStream;
 
-                    Stream baseStream = BaseNca.OpenSection(ProgramPartitionType.Data, true, IntegrityCheckLevel.None);
-                    if (baseStream == null) throw new InvalidDataException("Base NCA has no RomFS section");
+                    Stream baseStream = BaseNca.OpenSection(ProgramPartitionType.Data, true, IntegrityCheckLevel.None) ?? Stream.Null;
 
                     return new Bktr(rawStream, baseStream, sect);
 
@@ -162,10 +161,11 @@ namespace LibHac
         public Stream OpenSection(int index, bool raw, IntegrityCheckLevel integrityCheckLevel)
         {
             Stream rawStream = OpenRawSection(index);
+            
+            if (raw || rawStream == null) return rawStream;
+
             NcaSection sect = Sections[index];
             NcaFsHeader header = sect.Header;
-
-            if (raw || rawStream == null) return rawStream;
 
             // If it's a patch section without a base, return the raw section because it has no hash data
             if (header.EncryptionType == NcaEncryptionType.AesCtrEx && BaseNca == null) return rawStream;

--- a/LibHac/Nca.cs
+++ b/LibHac/Nca.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using LibHac.Streams;
 using LibHac.XTSSharp;
 
@@ -20,6 +19,9 @@ namespace LibHac
         private bool KeepOpen { get; }
         private Nca BaseNca { get; set; }
 
+        private bool IsMissingTitleKey { get; set; }
+        private string MissingKeyName { get; set; }
+
         public NcaSection[] Sections { get; } = new NcaSection[4];
 
         public Nca(Keyset keyset, Stream stream, bool keepOpen)
@@ -38,19 +40,20 @@ namespace LibHac
             {
                 DecryptKeyArea(keyset);
             }
+            else if (keyset.TitleKeys.TryGetValue(Header.RightsId, out byte[] titleKey))
+            {
+                if (keyset.Titlekeks[CryptoType].IsEmpty())
+                {
+                    MissingKeyName = $"titlekek_{CryptoType:x2}";
+                }
+
+                TitleKey = titleKey;
+                Crypto.DecryptEcb(keyset.Titlekeks[CryptoType], titleKey, TitleKeyDec, 0x10);
+                DecryptedKeys[2] = TitleKeyDec;
+            }
             else
             {
-                if (keyset.TitleKeys.TryGetValue(Header.RightsId, out byte[] titleKey))
-                {
-                    TitleKey = titleKey;
-                    Crypto.DecryptEcb(keyset.Titlekeks[CryptoType], titleKey, TitleKeyDec, 0x10);
-                    DecryptedKeys[2] = TitleKeyDec;
-                }
-                else
-                {
-                    // todo enable key check when opening a section
-                    // throw new MissingKeyException("A required key is missing.", $"{Header.RightsId.ToHexString()}", KeyType.Title);
-                }
+                IsMissingTitleKey = true;
             }
 
             for (int i = 0; i < 4; i++)
@@ -58,35 +61,68 @@ namespace LibHac
                 NcaSection section = ParseSection(i);
                 if (section == null) continue;
                 Sections[i] = section;
-                ValidateSuperblockHash(i);
+                ValidateMasterHash(i);
             }
 
-            foreach (NcaSection pfsSection in Sections.Where(x => x != null && x.Type == SectionType.Pfs0))
-            {
-                Stream sectionStream = OpenSection(pfsSection.SectionNum, false, false);
-                if (sectionStream == null) continue;
+            //foreach (NcaSection pfsSection in Sections.Where(x => x != null && x.Type == SectionType.Pfs0))
+            //{
+            //    Stream sectionStream = OpenSection(pfsSection.SectionNum, false, false);
+            //    if (sectionStream == null) continue;
 
-                var pfs = new Pfs(sectionStream);
-                if (!pfs.FileExists("main.npdm")) continue;
+            //    var pfs = new Pfs(sectionStream);
+            //    if (!pfs.FileExists("main.npdm")) continue;
 
-                pfsSection.IsExefs = true;
-            }
+            //    pfsSection.IsExefs = true;
+            //}
         }
 
+        /// <summary>
+        /// Opens a <see cref="Stream"/> of the underlying NCA file.
+        /// </summary>
+        /// <returns>A <see cref="Stream"/> that provides access to the entire raw NCA file.</returns>
         public Stream GetStream()
         {
             return StreamSource.CreateStream();
         }
 
+        public bool CanOpenSection(int index)
+        {
+            if (index < 0 || index > 3) throw new ArgumentOutOfRangeException(nameof(index));
+
+            NcaSection sect = Sections[index];
+            if (sect == null) return false;
+
+            return sect.Header.EncryptionType == NcaEncryptionType.None || !IsMissingTitleKey && string.IsNullOrWhiteSpace(MissingKeyName);
+        }
+
         private Stream OpenRawSection(int index)
         {
-            NcaSection sect = Sections[index];
-            if (sect == null) throw new ArgumentOutOfRangeException(nameof(index));
+            if (index < 0 || index > 3) throw new ArgumentOutOfRangeException(nameof(index));
 
-            //if (sect.SuperblockHashValidity == Validity.Invalid) return null;
+            NcaSection sect = Sections[index];
+            if (sect == null) return null;
+
+            if (sect.Header.EncryptionType != NcaEncryptionType.None)
+            {
+                if (IsMissingTitleKey)
+                {
+                    throw new MissingKeyException("Unable to decrypt NCA section.", Header.RightsId.ToHexString(), KeyType.Title);
+                }
+
+                if (!string.IsNullOrWhiteSpace(MissingKeyName))
+                {
+                    throw new MissingKeyException("Unable to decrypt NCA section.", MissingKeyName, KeyType.Common);
+                }
+            }
 
             long offset = sect.Offset;
             long size = sect.Size;
+
+            if (!Util.IsSubRange(offset, size, StreamSource.Length))
+            {
+                throw new InvalidDataException(
+                    $"Section offset (0x{offset:x}) and length (0x{size:x}) fall outside the total NCA length (0x{StreamSource.Length:x}).");
+            }
 
             Stream rawStream = StreamSource.CreateStream(offset, size);
 
@@ -104,10 +140,9 @@ namespace LibHac
                         false);
                     if (BaseNca == null) return rawStream;
 
-                    NcaSection baseSect = BaseNca.Sections.FirstOrDefault(x => x.Type == SectionType.Romfs);
-                    if (baseSect == null) throw new InvalidDataException("Base NCA has no RomFS section");
+                    Stream baseStream = BaseNca.OpenSection(ProgramPartitionType.Data, true, false);
+                    if (baseStream == null) throw new InvalidDataException("Base NCA has no RomFS section");
 
-                    Stream baseStream = BaseNca.OpenSection(baseSect.SectionNum, true, false);
                     return new Bktr(rawStream, baseStream, sect);
 
                 default:
@@ -115,24 +150,49 @@ namespace LibHac
             }
         }
 
+        /// <summary>
+        /// Opens one of the sections in the current <see cref="Nca"/>.
+        /// </summary>
+        /// <param name="index">The index of the NCA section to open. Valid indexes are 0-3.</param>
+        /// <param name="raw"><see langword="true"/> to open the raw section with hash metadata.</param>
+        /// <param name="enableIntegrityChecks"><see langword="true"/> to enable data integrity checks when reading the section.
+        /// Only applies if <paramref name="raw"/> is <see langword="false"/>.</param>
+        /// <returns>A <see cref="Stream"/> that provides access to the specified section. <see langword="null"/> if the section does not exist.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The specified <paramref name="index"/> is outside the valid range.</exception>
         public Stream OpenSection(int index, bool raw, bool enableIntegrityChecks)
         {
             Stream rawStream = OpenRawSection(index);
             NcaSection sect = Sections[index];
+            NcaFsHeader header = sect.Header;
 
             if (raw || rawStream == null) return rawStream;
 
-            switch (sect.Header.Type)
+            // If it's a patch section without a base, return the raw section because it has no hash data
+            if (header.EncryptionType == NcaEncryptionType.AesCtrEx && BaseNca == null) return rawStream;
+
+            switch (header.HashType)
             {
-                case SectionType.Pfs0:
-                    return InitIvfcForPartitionfs(sect.Header.Sha256Info, new SharedStreamSource(rawStream), enableIntegrityChecks);
-                case SectionType.Romfs:
-                case SectionType.Bktr:
-                    return InitIvfcForRomfs(sect.Header.IvfcInfo, new SharedStreamSource(rawStream), enableIntegrityChecks);
+                case NcaHashType.Sha256:
+                    return InitIvfcForPartitionfs(header.Sha256Info, new SharedStreamSource(rawStream), enableIntegrityChecks);
+                case NcaHashType.Ivfc:
+                    return InitIvfcForRomfs(header.IvfcInfo, new SharedStreamSource(rawStream), enableIntegrityChecks);
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
+
+        /// <summary>
+        /// Opens one of the sections in the current <see cref="Nca"/>. For use with <see cref="ContentType.Program"/> type NCAs.
+        /// </summary>
+        /// <param name="type">The type of section to open.</param>
+        /// <param name="raw"><see langword="true"/> to open the raw section with hash metadata.</param>
+        /// <param name="enableIntegrityChecks"><see langword="true"/> to enable data integrity checks when reading the section.
+        /// Only applies if <paramref name="raw"/> is <see langword="false"/>.</param>
+        /// <returns>A <see cref="Stream"/> that provides access to the specified section. <see langword="null"/> if the section does not exist.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The specified <paramref name="type"/> is outside the valid range.</exception>
+        public Stream OpenSection(ProgramPartitionType type, bool raw, bool enableIntegrityChecks) =>
+            OpenSection((int)type, raw, enableIntegrityChecks);
 
         private static HierarchicalIntegrityVerificationStream InitIvfcForRomfs(IvfcHeader ivfc,
             SharedStreamSource romfsStreamSource, bool enableIntegrityChecks)
@@ -195,10 +255,31 @@ namespace LibHac
             return new HierarchicalIntegrityVerificationStream(initInfo, enableIntegrityChecks);
         }
 
+        /// <summary>
+        /// Sets a base <see cref="Nca"/> to use when reading patches.
+        /// </summary>
+        /// <param name="baseNca">The base <see cref="Nca"/></param>
         public void SetBaseNca(Nca baseNca) => BaseNca = baseNca;
+
+        /// <summary>
+        /// Validates the master hash and store the result in <see cref="NcaSection.MasterHashValidity"/> for each <see cref="NcaSection"/>.
+        /// </summary>
+        public void ValidateMasterHashes()
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                if (Sections[i] == null) continue;
+                ValidateMasterHash(i);
+            }
+        }
 
         private void DecryptHeader(Keyset keyset, Stream stream)
         {
+            if (keyset.HeaderKey.IsEmpty())
+            {
+                throw new MissingKeyException("Unable to decrypt NCA header.", "header_key", KeyType.Common);
+            }
+
             var headerBytes = new byte[0xC00];
             Xts xts = XtsAes128.Create(keyset.HeaderKey);
             using (var headerDec = new RandomAccessSectorStream(new XtsSectorStream(stream, xts, 0x200)))
@@ -213,6 +294,12 @@ namespace LibHac
 
         private void DecryptKeyArea(Keyset keyset)
         {
+            if (keyset.KeyAreaKeys[CryptoType][Header.KaekInd].IsEmpty())
+            {
+                MissingKeyName = $"key_area_key_{Keyset.KakNames[Header.KaekInd]}_{CryptoType:x2}";
+                return;
+            }
+
             for (int i = 0; i < 4; i++)
             {
                 Crypto.DecryptEcb(keyset.KeyAreaKeys[CryptoType][Header.KaekInd], Header.EncryptedKeys[i],
@@ -239,6 +326,10 @@ namespace LibHac
 
         private void CheckBktrKey(NcaSection sect)
         {
+            // The encryption subsection table in the bktr partition contains the length of the entire partition.
+            // The encryption table is always located immediately following the partition data
+            // Decrypt this value and compare it to the encryption table offset found in the NCA header
+
             long offset = sect.Header.BktrInfo.EncryptionHeader.Offset;
             using (var streamDec = new RandomAccessSectorStream(new Aes128CtrStream(GetStream(), DecryptedKeys[2], sect.Offset, sect.Size, sect.Offset, sect.Header.Ctr)))
             {
@@ -248,17 +339,23 @@ namespace LibHac
 
                 if (size != offset)
                 {
-                    sect.SuperblockHashValidity = Validity.Invalid;
+                    sect.MasterHashValidity = Validity.Invalid;
                 }
             }
         }
 
-        private void ValidateSuperblockHash(int index)
+        private void ValidateMasterHash(int index)
         {
             if (Sections[index] == null) throw new ArgumentOutOfRangeException(nameof(index));
             NcaSection sect = Sections[index];
 
-            byte[] expected = null;
+            if (!CanOpenSection(index))
+            {
+                sect.MasterHashValidity = Validity.MissingKey;
+                return;
+            }
+
+            byte[] expected = sect.GetMasterHash();
             long offset = 0;
             long size = 0;
 
@@ -267,16 +364,12 @@ namespace LibHac
                 case SectionType.Invalid:
                     break;
                 case SectionType.Pfs0:
-                    Sha256Info pfs0 = sect.Header.Sha256Info;
-                    expected = pfs0.MasterHash;
-                    offset = pfs0.HashTableOffset;
-                    size = pfs0.HashTableSize;
+                    offset = sect.Header.Sha256Info.HashTableOffset;
+                    size = sect.Header.Sha256Info.HashTableSize;
                     break;
                 case SectionType.Romfs:
-                    IvfcHeader ivfc = sect.Header.IvfcInfo;
-                    expected = ivfc.MasterHash;
-                    offset = ivfc.LevelHeaders[0].LogicalOffset;
-                    size = 1 << ivfc.LevelHeaders[0].BlockSizePower;
+                    offset = sect.Header.IvfcInfo.LevelHeaders[0].LogicalOffset;
+                    size = 1 << sect.Header.IvfcInfo.LevelHeaders[0].BlockSizePower;
                     break;
                 case SectionType.Bktr:
                     CheckBktrKey(sect);
@@ -284,39 +377,33 @@ namespace LibHac
             }
 
             Stream stream = OpenSection(index, true, false);
-            if (stream == null) return;
-            if (expected == null) return;
 
             var hashTable = new byte[size];
             stream.Position = offset;
             stream.Read(hashTable, 0, hashTable.Length);
 
-            sect.SuperblockHashValidity = Crypto.CheckMemoryHashTable(hashTable, expected, 0, hashTable.Length);
-            // todo if (sect.Type == SectionType.Romfs) sect.Romfs.IvfcLevels[0].HashValidity = sect.SuperblockHashValidity;
+            sect.MasterHashValidity = Crypto.CheckMemoryHashTable(hashTable, expected, 0, hashTable.Length);
         }
 
         public void VerifySection(int index, IProgressReport logger = null)
         {
             if (Sections[index] == null) throw new ArgumentOutOfRangeException(nameof(index));
+
             NcaSection sect = Sections[index];
-            Stream stream = OpenSection(index, true, false);
+            Stream stream = OpenSection(index, false, true);
             logger?.LogMessage($"Verifying section {index}...");
 
-            switch (sect.Type)
+            switch (sect.Header.HashType)
             {
-                case SectionType.Invalid:
+                case NcaHashType.Sha256:
                     break;
-                case SectionType.Pfs0:
-                    // todo VerifyPfs0(stream, sect.Pfs0, logger);
+                case NcaHashType.Ivfc:
                     break;
-                case SectionType.Romfs:
-                    // todo VerifyIvfc(stream, sect.Romfs.IvfcLevels, logger);
-                    break;
-                case SectionType.Bktr:
-                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
-        
+
         public void Dispose()
         {
             if (!KeepOpen)
@@ -333,9 +420,26 @@ namespace LibHac
         public int SectionNum { get; set; }
         public long Offset { get; set; }
         public long Size { get; set; }
-        public Validity SuperblockHashValidity { get; set; }
+        public Validity MasterHashValidity { get; set; }
 
         public bool IsExefs { get; internal set; }
+
+        public byte[] GetMasterHash()
+        {
+            var hash = new byte[Crypto.Sha256DigestSize];
+
+            switch (Header.HashType)
+            {
+                case NcaHashType.Sha256:
+                    Array.Copy(Header.Sha256Info.MasterHash, hash, Crypto.Sha256DigestSize);
+                    break;
+                case NcaHashType.Ivfc:
+                    Array.Copy(Header.IvfcInfo.MasterHash, hash, Crypto.Sha256DigestSize);
+                    break;
+            }
+
+            return hash;
+        }
     }
 
     public static class NcaExtensions

--- a/LibHac/Nca.cs
+++ b/LibHac/Nca.cs
@@ -61,19 +61,7 @@ namespace LibHac
                 NcaSection section = ParseSection(i);
                 if (section == null) continue;
                 Sections[i] = section;
-                ValidateMasterHash(i);
             }
-
-            //foreach (NcaSection pfsSection in Sections.Where(x => x != null && x.Type == SectionType.Pfs0))
-            //{
-            //    Stream sectionStream = OpenSection(pfsSection.SectionNum, false, false);
-            //    if (sectionStream == null) continue;
-
-            //    var pfs = new Pfs(sectionStream);
-            //    if (!pfs.FileExists("main.npdm")) continue;
-
-            //    pfsSection.IsExefs = true;
-            //}
         }
 
         /// <summary>
@@ -161,7 +149,7 @@ namespace LibHac
         public Stream OpenSection(int index, bool raw, IntegrityCheckLevel integrityCheckLevel)
         {
             Stream rawStream = OpenRawSection(index);
-            
+
             if (raw || rawStream == null) return rawStream;
 
             NcaSection sect = Sections[index];
@@ -379,7 +367,7 @@ namespace LibHac
                     break;
                 case NcaHashType.Ivfc when sect.Header.EncryptionType == NcaEncryptionType.AesCtrEx:
                     CheckBktrKey(sect);
-                    break;
+                    return;
                 case NcaHashType.Ivfc:
                     offset = sect.Header.IvfcInfo.LevelHeaders[0].LogicalOffset;
                     size = 1 << sect.Header.IvfcInfo.LevelHeaders[0].BlockSizePower;
@@ -413,8 +401,6 @@ namespace LibHac
         public long Offset { get; set; }
         public long Size { get; set; }
         public Validity MasterHashValidity { get; set; }
-
-        public bool IsExefs { get; internal set; }
 
         public byte[] GetMasterHash()
         {

--- a/LibHac/NcaStructs.cs
+++ b/LibHac/NcaStructs.cs
@@ -148,32 +148,6 @@ namespace LibHac
         }
     }
 
-    public class RomfsSuperblock
-    {
-        public IvfcHeader IvfcHeader;
-
-        public RomfsSuperblock(BinaryReader reader)
-        {
-            IvfcHeader = new IvfcHeader(reader);
-            reader.BaseStream.Position += 0x58;
-        }
-    }
-
-    public class BktrSuperblock
-    {
-        public IvfcHeader IvfcHeader;
-        public BktrHeader RelocationHeader;
-        public BktrHeader SubsectionHeader;
-
-        public BktrSuperblock(BinaryReader reader)
-        {
-            IvfcHeader = new IvfcHeader(reader);
-            reader.BaseStream.Position += 0x18;
-            RelocationHeader = new BktrHeader(reader);
-            SubsectionHeader = new BktrHeader(reader);
-        }
-    }
-
     public class BktrPatchInfo
     {
         public BktrHeader RelocationHeader;
@@ -302,18 +276,6 @@ namespace LibHac
         {
             return $"{Major}.{Minor}.{Patch}.{Revision}";
         }
-    }
-
-    public class Pfs0Section
-    {
-        public PfsSuperblock Superblock { get; set; }
-        public Validity Validity { get; set; }
-    }
-
-    public class RomfsSection
-    {
-        public RomfsSuperblock Superblock { get; set; }
-        public IvfcLevel[] IvfcLevels { get; set; } = new IvfcLevel[Romfs.IvfcMaxLevel];
     }
 
     public enum ProgramPartitionType

--- a/LibHac/NcaStructs.cs
+++ b/LibHac/NcaStructs.cs
@@ -215,6 +215,8 @@ namespace LibHac
         public int BlockSizePower;
         public uint Reserved;
 
+        public Validity HashValidity = Validity.Unchecked;
+
         public IvfcLevelHeader(BinaryReader reader)
         {
             LogicalOffset = reader.ReadInt64();
@@ -234,6 +236,8 @@ namespace LibHac
         public long DataOffset;
         public long DataSize;
 
+        public Validity HashValidity = Validity.Unchecked;
+        
         public Sha256Info(BinaryReader reader)
         {
             MasterHash = reader.ReadBytes(0x20);
@@ -366,7 +370,7 @@ namespace LibHac
         Bktr
     }
 
-    public enum Validity
+    public enum Validity : byte
     {
         Unchecked,
         Invalid,

--- a/LibHac/NcaStructs.cs
+++ b/LibHac/NcaStructs.cs
@@ -312,6 +312,13 @@ namespace LibHac
         public IvfcLevel[] IvfcLevels { get; set; } = new IvfcLevel[Romfs.IvfcMaxLevel];
     }
 
+    public enum ProgramPartitionType
+    {
+        Code,
+        Data,
+        Logo
+    };
+
     public enum ContentType
     {
         Program,
@@ -363,6 +370,7 @@ namespace LibHac
     {
         Unchecked,
         Invalid,
-        Valid
+        Valid,
+        MissingKey
     }
 }

--- a/LibHac/Pfs.cs
+++ b/LibHac/Pfs.cs
@@ -68,29 +68,6 @@ namespace LibHac
         Hfs0
     }
 
-    public class PfsSuperblock
-    {
-        public byte[] MasterHash; /* SHA-256 hash of the hash table. */
-        public int BlockSize; /* In bytes. */
-        public uint Always2;
-        public long HashTableOffset; /* Normally zero. */
-        public long HashTableSize;
-        public long Pfs0Offset;
-        public long Pfs0Size;
-
-        public PfsSuperblock(BinaryReader reader)
-        {
-            MasterHash = reader.ReadBytes(0x20);
-            BlockSize = reader.ReadInt32();
-            Always2 = reader.ReadUInt32();
-            HashTableOffset = reader.ReadInt64();
-            HashTableSize = reader.ReadInt64();
-            Pfs0Offset = reader.ReadInt64();
-            Pfs0Size = reader.ReadInt64();
-            reader.BaseStream.Position += 0xF0;
-        }
-    }
-
     public class PfsHeader
     {
         public string Magic;

--- a/LibHac/Romfs.cs
+++ b/LibHac/Romfs.cs
@@ -143,19 +143,6 @@ namespace LibHac
         }
     }
 
-    
-
-    public class IvfcLevel
-    {
-        public long DataOffset { get; set; }
-        public long DataSize { get; set; }
-        public long HashOffset { get; set; }
-        public long HashSize { get; set; }
-        public long HashBlockSize { get; set; }
-        public long HashBlockCount { get; set; }
-        public Validity HashValidity { get; set; }
-    }
-
     public static class RomfsExtensions
     {
         public static void Extract(this Romfs romfs, string outDir, IProgressReport logger = null)

--- a/LibHac/Savefile/Savefile.cs
+++ b/LibHac/Savefile/Savefile.cs
@@ -41,7 +41,7 @@ namespace LibHac.Savefile
         public DirectoryEntry[] Directories { get; private set; }
         private Dictionary<string, FileEntry> FileDict { get; }
 
-        public Savefile(Keyset keyset, Stream file, bool enableIntegrityChecks)
+        public Savefile(Keyset keyset, Stream file, IntegrityCheckLevel integrityCheckLevel)
         {
             SavefileSource = new SharedStreamSource(file);
 
@@ -106,7 +106,7 @@ namespace LibHac.Savefile
                 JournalStream = new JournalStream(journalData, journalMap, (int)Header.Journal.BlockSize);
                 JournalStreamSource = new SharedStreamSource(JournalStream);
 
-                IvfcStream = InitIvfcStream(enableIntegrityChecks);
+                IvfcStream = InitIvfcStream(integrityCheckLevel);
                 IvfcStreamSource = new SharedStreamSource(IvfcStream);
 
                 ReadFileInfo();
@@ -120,7 +120,7 @@ namespace LibHac.Savefile
             }
         }
 
-        private HierarchicalIntegrityVerificationStream InitIvfcStream(bool enableIntegrityChecks)
+        private HierarchicalIntegrityVerificationStream InitIvfcStream(IntegrityCheckLevel integrityCheckLevel)
         {
             IvfcHeader ivfc = Header.Ivfc;
 
@@ -151,7 +151,7 @@ namespace LibHac.Savefile
                 };
             }
 
-            return new HierarchicalIntegrityVerificationStream(initInfo, enableIntegrityChecks);
+            return new HierarchicalIntegrityVerificationStream(initInfo, integrityCheckLevel);
         }
 
         public Stream OpenFile(string filename)

--- a/LibHac/Streams/CombinationStream.cs
+++ b/LibHac/Streams/CombinationStream.cs
@@ -83,7 +83,7 @@ namespace LibHac.Streams
                     break;
             }
             int idx = 0;
-            while (idx+1 < _streamsStartPos.Count)
+            while (idx + 1 < _streamsStartPos.Count)
             {
                 if (_streamsStartPos[idx + 1] > pos)
                 {
@@ -122,10 +122,11 @@ namespace LibHac.Streams
 
                 if (count > 0)
                 {
-                    if (_currentStreamIndex >= _streams.Count)
+                    if (_currentStreamIndex + 1 >= _streams.Count)
                         break;
 
-                    _currentStream = _streams[_currentStreamIndex++];
+                    _currentStream = _streams[_currentStreamIndex + 1];
+                    _currentStreamIndex++;
                     _currentStream.Position = 0;
                 }
             }

--- a/LibHac/Streams/SectorStream.cs
+++ b/LibHac/Streams/SectorStream.cs
@@ -16,6 +16,11 @@ namespace LibHac.Streams
         public int SectorSize { get; }
 
         /// <summary>
+        /// The number of sectors in the stream.
+        /// </summary>
+        public int SectorCount { get; }
+
+        /// <summary>
         /// The maximum number of sectors that can be read or written in a single operation.
         /// </summary>
         public int MaxSectors { get; }
@@ -64,6 +69,8 @@ namespace LibHac.Streams
             _keepOpen = keepOpen;
             _maxBufferSize = MaxSectors * SectorSize;
             baseStream.Position = offset;
+
+            SectorCount = (int)Util.DivideByRoundUp(_baseStream.Length - _offset, sectorSize);
         }
 
         public override void Flush()

--- a/LibHac/SwitchFs.cs
+++ b/LibHac/SwitchFs.cs
@@ -126,7 +126,7 @@ namespace LibHac
 
                     string sdPath = "/" + Util.GetRelativePath(file, SaveDir).Replace('\\', '/');
                     var nax0 = new Nax0(Keyset, stream, sdPath, false);
-                    save = new Savefile.Savefile(Keyset, nax0.Stream, false);
+                    save = new Savefile.Savefile(Keyset, nax0.Stream, IntegrityCheckLevel.None);
                 }
                 catch (Exception ex)
                 {
@@ -147,7 +147,7 @@ namespace LibHac
                 var title = new Title();
 
                 // Meta contents always have 1 Partition FS section with 1 file in it
-                Stream sect = nca.OpenSection(0, false, true);
+                Stream sect = nca.OpenSection(0, false, IntegrityCheckLevel.ErrorOnInvalid);
                 var pfs0 = new Pfs(sect);
                 Stream file = pfs0.OpenFile(pfs0.Files[0]);
 
@@ -187,7 +187,7 @@ namespace LibHac
         {
             foreach (Title title in Titles.Values.Where(x => x.ControlNca != null))
             {
-                var romfs = new Romfs(title.ControlNca.OpenSection(0, false, true));
+                var romfs = new Romfs(title.ControlNca.OpenSection(0, false, IntegrityCheckLevel.ErrorOnInvalid));
                 byte[] control = romfs.GetFile("/control.nacp");
 
                 var reader = new BinaryReader(new MemoryStream(control));

--- a/LibHac/Util.cs
+++ b/LibHac/Util.cs
@@ -399,9 +399,15 @@ namespace LibHac
                 case 2: return "3.0.1-3.0.2";
                 case 3: return "4.0.0-4.1.0";
                 case 4: return "5.0.0-5.1.0";
-                case 5: return "6.0.0";
+                case 5: return "6.0.0-6.0.1";
                 default: return "Unknown";
             }
+        }
+
+        public static bool IsSubRange(long startIndex, long subLength, long length)
+        {
+            bool isOutOfRange = startIndex < 0 || startIndex > length || subLength < 0 || startIndex > length - subLength;
+            return !isOutOfRange;
         }
     }
 

--- a/NandReader/Program.cs
+++ b/NandReader/Program.cs
@@ -102,7 +102,7 @@ namespace NandReader
         private static List<Ticket> ReadTickets(Keyset keyset, Stream savefile)
         {
             var tickets = new List<Ticket>();
-            var save = new Savefile(keyset, savefile, false);
+            var save = new Savefile(keyset, savefile, IntegrityCheckLevel.None);
             var ticketList = new BinaryReader(save.OpenFile("/ticket_list.bin"));
             var ticketFile = new BinaryReader(save.OpenFile("/ticket.bin"));
 

--- a/NandReaderGui/ViewModel/NandViewModel.cs
+++ b/NandReaderGui/ViewModel/NandViewModel.cs
@@ -84,7 +84,7 @@ namespace NandReaderGui.ViewModel
         private static List<Ticket> ReadTickets(Keyset keyset, Stream savefile)
         {
             var tickets = new List<Ticket>();
-            var save = new Savefile(keyset, savefile, false);
+            var save = new Savefile(keyset, savefile, IntegrityCheckLevel.None);
             var ticketList = new BinaryReader(save.OpenFile("/ticket_list.bin"));
             var ticketFile = new BinaryReader(save.OpenFile("/ticket.bin"));
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ hactoolnet is an example program that uses LibHac. It is used in a similar manne
 Usage: hactoolnet.exe [options...] <path>
 Options:
   -r, --raw            Keep raw data, don't unpack.
-  -y, --verify         Verify hashes.
+  -y, --verify         Verify all hashes in the input file.
+  -h, --enablehash     Enable hash checks when reading the input file.
   -k, --keyset         Load keys from an external file.
-  -t, --intype=type    Specify input file type [nca, xci, romfs, pk11, pk21, switchfs, save, keygen]
+  -t, --intype=type    Specify input file type [nca, xci, romfs, pk11, pk21, ini1, kip1, switchfs, save, keygen]
   --titlekeys <file>   Load title keys from an external file.
 NCA options:
   --section0 <file>    Specify Section 0 file path.
@@ -53,6 +54,8 @@ Package1 options:
   --outdir <dir>       Specify Package1 directory path.
 Package2 options:
   --outdir <dir>       Specify Package2 directory path.
+INI1 options:
+  --outdir <dir>       Specify INI1 directory path.
 Switch FS options:
   --sdseed <seed>      Set console unique seed for SD card NAX0 encryption.
   --listapps           List application info.
@@ -64,10 +67,13 @@ Switch FS options:
   --romfs <file>       Specify RomFS directory path. (--title must be specified)
   --romfsdir <dir>     Specify RomFS directory path. (--title must be specified)
   --savedir <dir>      Specify save file directory path.
+  -y, --verify         Verify all titles, or verify a single title if --title is set.
 Savefile options:
   --outdir <dir>       Specify directory path to save contents to.
   --debugoutdir <dir>  Specify directory path to save intermediate data to for debugging.
   --sign               Sign the save file. (Requires device_key in key file)
+Keygen options:
+  --outdir <dir>       Specify directory path to save key files to.
 ```
 
 ## Examples

--- a/hactoolnet/CliParser.cs
+++ b/hactoolnet/CliParser.cs
@@ -198,6 +198,7 @@ namespace hactoolnet
             sb.AppendLine("  --romfs <file>       Specify RomFS directory path. (--title must be specified)");
             sb.AppendLine("  --romfsdir <dir>     Specify RomFS directory path. (--title must be specified)");
             sb.AppendLine("  --savedir <dir>      Specify save file directory path.");
+            sb.AppendLine("  -y, --verify         Verify all titles, or verify a single title if --title is set.");
             sb.AppendLine("Savefile options:");
             sb.AppendLine("  --outdir <dir>       Specify directory path to save contents to.");
             sb.AppendLine("  --debugoutdir <dir>  Specify directory path to save intermediate data to for debugging.");

--- a/hactoolnet/Options.cs
+++ b/hactoolnet/Options.cs
@@ -36,6 +36,9 @@ namespace hactoolnet
         public bool ListRomFs;
         public bool SignSave;
         public ulong TitleId;
+
+        public IntegrityCheckLevel IntegrityLevel =>
+            EnableHash ? IntegrityCheckLevel.ErrorOnInvalid : IntegrityCheckLevel.None;
     }
 
     internal enum FileType

--- a/hactoolnet/ProcessNca.cs
+++ b/hactoolnet/ProcessNca.cs
@@ -13,6 +13,7 @@ namespace hactoolnet
             using (var file = new FileStream(ctx.Options.InFile, FileMode.Open, FileAccess.Read))
             {
                 var nca = new Nca(ctx.Keyset, file, false);
+                nca.ValidateMasterHashes();
 
                 if (ctx.Options.BaseNca != null)
                 {
@@ -180,7 +181,7 @@ namespace hactoolnet
             {
                 Sha256Info hashInfo = sect.Header.Sha256Info;
 
-                PrintItem(sb, colLen, $"        Superblock Hash{sect.SuperblockHashValidity.GetValidityString()}:", hashInfo.MasterHash);
+                PrintItem(sb, colLen, $"        Superblock Hash{sect.MasterHashValidity.GetValidityString()}:", hashInfo.MasterHash);
                 // todo sb.AppendLine($"        Hash Table{sect.Pfs0.Validity.GetValidityString()}:");
                 sb.AppendLine($"        Hash Table:");
 
@@ -195,7 +196,7 @@ namespace hactoolnet
             {
                 IvfcHeader ivfcInfo = sect.Header.IvfcInfo;
 
-                PrintItem(sb, colLen, $"        Superblock Hash{sect.SuperblockHashValidity.GetValidityString()}:", ivfcInfo.MasterHash);
+                PrintItem(sb, colLen, $"        Superblock Hash{sect.MasterHashValidity.GetValidityString()}:", ivfcInfo.MasterHash);
                 PrintItem(sb, colLen, "        Magic:", ivfcInfo.Magic);
                 PrintItem(sb, colLen, "        Version:", $"{ivfcInfo.Version:x8}");
 

--- a/hactoolnet/ProcessNca.cs
+++ b/hactoolnet/ProcessNca.cs
@@ -80,7 +80,13 @@ namespace hactoolnet
 
                 if (ctx.Options.ExefsOutDir != null || ctx.Options.ExefsOut != null)
                 {
-                    NcaSection section = nca.Sections.FirstOrDefault(x => x?.IsExefs == true);
+                    if (nca.Header.ContentType != ContentType.Program)
+                    {
+                        ctx.Logger.LogMessage("NCA's content type is not \"Program\"");
+                        return;
+                    }
+
+                    NcaSection section = nca.Sections[(int)ProgramPartitionType.Code];
 
                     if (section == null)
                     {
@@ -154,10 +160,12 @@ namespace hactoolnet
                     NcaSection sect = nca.Sections[i];
                     if (sect == null) continue;
 
+                    bool isExefs = nca.Header.ContentType == ContentType.Program && i == (int)ProgramPartitionType.Code;
+
                     sb.AppendLine($"    Section {i}:");
                     PrintItem(sb, colLen, "        Offset:", $"0x{sect.Offset:x12}");
                     PrintItem(sb, colLen, "        Size:", $"0x{sect.Size:x12}");
-                    PrintItem(sb, colLen, "        Partition Type:", sect.IsExefs ? "ExeFS" : sect.Type.ToString());
+                    PrintItem(sb, colLen, "        Partition Type:", isExefs ? "ExeFS" : sect.Type.ToString());
                     PrintItem(sb, colLen, "        Section CTR:", sect.Header.Ctr);
 
                     switch (sect.Header.HashType)

--- a/hactoolnet/ProcessNca.cs
+++ b/hactoolnet/ProcessNca.cs
@@ -160,16 +160,13 @@ namespace hactoolnet
                     PrintItem(sb, colLen, "        Partition Type:", sect.IsExefs ? "ExeFS" : sect.Type.ToString());
                     PrintItem(sb, colLen, "        Section CTR:", sect.Header.Ctr);
 
-                    switch (sect.Type)
+                    switch (sect.Header.HashType)
                     {
-                        case SectionType.Pfs0:
-                            PrintPfs0(sect);
+                        case NcaHashType.Sha256:
+                            PrintSha256Hash(sect);
                             break;
-                        case SectionType.Romfs:
-                            PrintRomfs(sect);
-                            break;
-                        case SectionType.Bktr:
-                            PrintRomfs(sect);
+                        case NcaHashType.Ivfc:
+                            PrintIvfcHash(sect);
                             break;
                         default:
                             sb.AppendLine("        Unknown/invalid superblock!");
@@ -178,7 +175,7 @@ namespace hactoolnet
                 }
             }
 
-            void PrintPfs0(NcaSection sect)
+            void PrintSha256Hash(NcaSection sect)
             {
                 Sha256Info hashInfo = sect.Header.Sha256Info;
 
@@ -192,7 +189,7 @@ namespace hactoolnet
                 PrintItem(sb, colLen, "        PFS0 Size:", $"0x{hashInfo.DataSize:x12}");
             }
 
-            void PrintRomfs(NcaSection sect)
+            void PrintIvfcHash(NcaSection sect)
             {
                 IvfcHeader ivfcInfo = sect.Header.IvfcInfo;
 

--- a/hactoolnet/ProcessNca.cs
+++ b/hactoolnet/ProcessNca.cs
@@ -169,6 +169,7 @@ namespace hactoolnet
                             PrintRomfs(sect);
                             break;
                         case SectionType.Bktr:
+                            PrintRomfs(sect);
                             break;
                         default:
                             sb.AppendLine("        Unknown/invalid superblock!");
@@ -181,9 +182,8 @@ namespace hactoolnet
             {
                 Sha256Info hashInfo = sect.Header.Sha256Info;
 
-                PrintItem(sb, colLen, $"        Superblock Hash{sect.MasterHashValidity.GetValidityString()}:", hashInfo.MasterHash);
-                // todo sb.AppendLine($"        Hash Table{sect.Pfs0.Validity.GetValidityString()}:");
-                sb.AppendLine($"        Hash Table:");
+                PrintItem(sb, colLen, $"        Master Hash{sect.MasterHashValidity.GetValidityString()}:", hashInfo.MasterHash);
+                sb.AppendLine($"        Hash Table{sect.Header.Sha256Info.HashValidity.GetValidityString()}:");
 
                 PrintItem(sb, colLen, "            Offset:", $"0x{hashInfo.HashTableOffset:x12}");
                 PrintItem(sb, colLen, "            Size:", $"0x{hashInfo.HashTableSize:x12}");
@@ -196,7 +196,7 @@ namespace hactoolnet
             {
                 IvfcHeader ivfcInfo = sect.Header.IvfcInfo;
 
-                PrintItem(sb, colLen, $"        Superblock Hash{sect.MasterHashValidity.GetValidityString()}:", ivfcInfo.MasterHash);
+                PrintItem(sb, colLen, $"        Master Hash{sect.MasterHashValidity.GetValidityString()}:", ivfcInfo.MasterHash);
                 PrintItem(sb, colLen, "        Magic:", ivfcInfo.Magic);
                 PrintItem(sb, colLen, "        Version:", $"{ivfcInfo.Version:x8}");
 
@@ -210,8 +210,7 @@ namespace hactoolnet
                         hashOffset = ivfcInfo.LevelHeaders[i - 1].LogicalOffset;
                     }
 
-                    // todo  sb.AppendLine($"        Level {i}{level.HashValidity.GetValidityString()}:");
-                    sb.AppendLine($"        Level {i}:");
+                    sb.AppendLine($"        Level {i}{level.HashValidity.GetValidityString()}:");
                     PrintItem(sb, colLen, "            Data Offset:", $"0x{level.LogicalOffset:x12}");
                     PrintItem(sb, colLen, "            Data Size:", $"0x{level.HashDataSize:x12}");
                     PrintItem(sb, colLen, "            Hash Offset:", $"0x{hashOffset:x12}");

--- a/hactoolnet/ProcessNca.cs
+++ b/hactoolnet/ProcessNca.cs
@@ -26,12 +26,12 @@ namespace hactoolnet
                 {
                     if (ctx.Options.SectionOut[i] != null)
                     {
-                        nca.ExportSection(i, ctx.Options.SectionOut[i], ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                        nca.ExportSection(i, ctx.Options.SectionOut[i], ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
 
                     if (ctx.Options.SectionOutDir[i] != null)
                     {
-                        nca.ExtractSection(i, ctx.Options.SectionOutDir[i], ctx.Options.EnableHash, ctx.Logger);
+                        nca.ExtractSection(i, ctx.Options.SectionOutDir[i], ctx.Options.IntegrityLevel, ctx.Logger);
                     }
 
                     if (ctx.Options.Validate && nca.Sections[i] != null)
@@ -42,7 +42,7 @@ namespace hactoolnet
 
                 if (ctx.Options.ListRomFs && nca.Sections[1] != null)
                 {
-                    var romfs = new Romfs(nca.OpenSection(1, false, ctx.Options.EnableHash));
+                    var romfs = new Romfs(nca.OpenSection(1, false, ctx.Options.IntegrityLevel));
 
                     foreach (RomfsFile romfsFile in romfs.Files)
                     {
@@ -68,12 +68,12 @@ namespace hactoolnet
 
                     if (ctx.Options.RomfsOut != null)
                     {
-                        nca.ExportSection(section.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                        nca.ExportSection(section.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
 
                     if (ctx.Options.RomfsOutDir != null)
                     {
-                        var romfs = new Romfs(nca.OpenSection(section.SectionNum, false, ctx.Options.EnableHash));
+                        var romfs = new Romfs(nca.OpenSection(section.SectionNum, false, ctx.Options.IntegrityLevel));
                         romfs.Extract(ctx.Options.RomfsOutDir, ctx.Logger);
                     }
                 }
@@ -90,12 +90,12 @@ namespace hactoolnet
 
                     if (ctx.Options.ExefsOut != null)
                     {
-                        nca.ExportSection(section.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                        nca.ExportSection(section.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
 
                     if (ctx.Options.ExefsOutDir != null)
                     {
-                        nca.ExtractSection(section.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.EnableHash, ctx.Logger);
+                        nca.ExtractSection(section.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
                 }
 

--- a/hactoolnet/ProcessSave.cs
+++ b/hactoolnet/ProcessSave.cs
@@ -14,7 +14,7 @@ namespace hactoolnet
         {
             using (var file = new FileStream(ctx.Options.InFile, FileMode.Open, FileAccess.ReadWrite))
             {
-                var save = new Savefile(ctx.Keyset, file, ctx.Options.EnableHash);
+                var save = new Savefile(ctx.Keyset, file, ctx.Options.IntegrityLevel);
 
                 if (ctx.Options.OutDir != null)
                 {

--- a/hactoolnet/ProcessSwitchFs.cs
+++ b/hactoolnet/ProcessSwitchFs.cs
@@ -55,12 +55,12 @@ namespace hactoolnet
 
                 if (ctx.Options.ExefsOutDir != null)
                 {
-                    title.MainNca.ExtractSection(section.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.EnableHash, ctx.Logger);
+                    title.MainNca.ExtractSection(section.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.IntegrityLevel, ctx.Logger);
                 }
 
                 if (ctx.Options.ExefsOut != null)
                 {
-                    title.MainNca.ExportSection(section.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                    title.MainNca.ExportSection(section.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                 }
             }
 
@@ -95,13 +95,13 @@ namespace hactoolnet
 
                 if (ctx.Options.RomfsOutDir != null)
                 {
-                    var romfs = new Romfs(title.MainNca.OpenSection(section.SectionNum, false, ctx.Options.EnableHash));
+                    var romfs = new Romfs(title.MainNca.OpenSection(section.SectionNum, false, ctx.Options.IntegrityLevel));
                     romfs.Extract(ctx.Options.RomfsOutDir, ctx.Logger);
                 }
 
                 if (ctx.Options.RomfsOut != null)
                 {
-                    title.MainNca.ExportSection(section.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                    title.MainNca.ExportSection(section.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                 }
             }
 

--- a/hactoolnet/ProcessSwitchFs.cs
+++ b/hactoolnet/ProcessSwitchFs.cs
@@ -170,7 +170,7 @@ namespace hactoolnet
 
                     foreach (NcaSection sect in nca.Sections.Where(x => x != null))
                     {
-                        Console.WriteLine($"        {sect.SectionNum} {sect.Type} {sect.Header.EncryptionType} {sect.SuperblockHashValidity}");
+                        Console.WriteLine($"        {sect.SectionNum} {sect.Type} {sect.Header.EncryptionType} {sect.MasterHashValidity}");
                     }
                 }
 

--- a/hactoolnet/ProcessSwitchFs.cs
+++ b/hactoolnet/ProcessSwitchFs.cs
@@ -45,7 +45,7 @@ namespace hactoolnet
                     return;
                 }
 
-                NcaSection section = title.MainNca.Sections.FirstOrDefault(x => x.IsExefs);
+                NcaSection section = title.MainNca.Sections[(int)ProgramPartitionType.Code];
 
                 if (section == null)
                 {

--- a/hactoolnet/ProcessXci.cs
+++ b/hactoolnet/ProcessXci.cs
@@ -69,7 +69,7 @@ namespace hactoolnet
                         return;
                     }
 
-                    NcaSection exefsSection = mainNca.Sections.FirstOrDefault(x => x.IsExefs);
+                    NcaSection exefsSection = mainNca.Sections[(int)ProgramPartitionType.Code];
 
                     if (exefsSection == null)
                     {

--- a/hactoolnet/ProcessXci.cs
+++ b/hactoolnet/ProcessXci.cs
@@ -79,12 +79,12 @@ namespace hactoolnet
 
                     if (ctx.Options.ExefsOutDir != null)
                     {
-                        mainNca.ExtractSection(exefsSection.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.EnableHash, ctx.Logger);
+                        mainNca.ExtractSection(exefsSection.SectionNum, ctx.Options.ExefsOutDir, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
 
                     if (ctx.Options.ExefsOut != null)
                     {
-                        mainNca.ExportSection(exefsSection.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                        mainNca.ExportSection(exefsSection.SectionNum, ctx.Options.ExefsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
                 }
 
@@ -108,13 +108,13 @@ namespace hactoolnet
 
                     if (ctx.Options.RomfsOutDir != null)
                     {
-                        var romfs = new Romfs(mainNca.OpenSection(romfsSection.SectionNum, false, ctx.Options.EnableHash));
+                        var romfs = new Romfs(mainNca.OpenSection(romfsSection.SectionNum, false, ctx.Options.IntegrityLevel));
                         romfs.Extract(ctx.Options.RomfsOutDir, ctx.Logger);
                     }
 
                     if (ctx.Options.RomfsOut != null)
                     {
-                        mainNca.ExportSection(romfsSection.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.EnableHash, ctx.Logger);
+                        mainNca.ExportSection(romfsSection.SectionNum, ctx.Options.RomfsOut, ctx.Options.Raw, ctx.Options.IntegrityLevel, ctx.Logger);
                     }
                 }
             }

--- a/hactoolnet/Program.cs
+++ b/hactoolnet/Program.cs
@@ -9,6 +9,27 @@ namespace hactoolnet
     {
         public static void Main(string[] args)
         {
+            try
+            {
+                Run(args);
+            }
+            catch (MissingKeyException ex)
+            {
+                string name = ex.Type == KeyType.Title ? $"Title key for rights ID {ex.Name}" : ex.Name;
+                Console.WriteLine($"\nERROR: {ex.Message}\nA required key is missing.\nKey name: {name}\n");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"\nERROR: {ex.Message}\n");
+
+                Console.WriteLine("Additional information:");
+                Console.WriteLine(ex.GetType().FullName);
+                Console.WriteLine(ex.StackTrace);
+            }
+        }
+
+        private static void Run(string[] args)
+        {
             Console.OutputEncoding = Encoding.UTF8;
             var ctx = new Context();
             ctx.Options = CliParser.Parse(args);
@@ -25,47 +46,52 @@ namespace hactoolnet
                     return;
                 }
 
-                switch (ctx.Options.InFileType)
-                {
-                    case FileType.Nca:
-                        ProcessNca.Process(ctx);
-                        break;
-                    case FileType.Pfs0:
-                    case FileType.Nsp:
-                        ProcessNsp.Process(ctx);
-                        break;
-                    case FileType.Romfs:
-                        ProcessRomfs.Process(ctx);
-                        break;
-                    case FileType.Nax0:
-                        break;
-                    case FileType.SwitchFs:
-                        ProcessSwitchFs.Process(ctx);
-                        break;
-                    case FileType.Save:
-                        ProcessSave.Process(ctx);
-                        break;
-                    case FileType.Xci:
-                        ProcessXci.Process(ctx);
-                        break;
-                    case FileType.Keygen:
-                        ProcessKeygen(ctx);
-                        break;
-                    case FileType.Pk11:
-                        ProcessPackage.ProcessPk11(ctx);
-                        break;
-                    case FileType.Pk21:
-                        ProcessPackage.ProcessPk21(ctx);
-                        break;
-                    case FileType.Kip1:
-                        ProcessKip.ProcessKip1(ctx);
-                        break;
-                    case FileType.Ini1:
-                        ProcessKip.ProcessIni1(ctx);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                RunTask(ctx);
+            }
+        }
+
+        private static void RunTask(Context ctx)
+        {
+            switch (ctx.Options.InFileType)
+            {
+                case FileType.Nca:
+                    ProcessNca.Process(ctx);
+                    break;
+                case FileType.Pfs0:
+                case FileType.Nsp:
+                    ProcessNsp.Process(ctx);
+                    break;
+                case FileType.Romfs:
+                    ProcessRomfs.Process(ctx);
+                    break;
+                case FileType.Nax0:
+                    break;
+                case FileType.SwitchFs:
+                    ProcessSwitchFs.Process(ctx);
+                    break;
+                case FileType.Save:
+                    ProcessSave.Process(ctx);
+                    break;
+                case FileType.Xci:
+                    ProcessXci.Process(ctx);
+                    break;
+                case FileType.Keygen:
+                    ProcessKeygen(ctx);
+                    break;
+                case FileType.Pk11:
+                    ProcessPackage.ProcessPk11(ctx);
+                    break;
+                case FileType.Pk21:
+                    ProcessPackage.ProcessPk21(ctx);
+                    break;
+                case FileType.Kip1:
+                    ProcessKip.ProcessKip1(ctx);
+                    break;
+                case FileType.Ini1:
+                    ProcessKip.ProcessIni1(ctx);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 


### PR DESCRIPTION
- Read only the NCA header when first opening an NCA. This allows for reading of partial NCAs and slightly improves performance when opening an NCA.
- Add a separate NCA method to validate master hashes now that it's not automatically done when opening the NCA.
- Fix possible hang when reading BKTR sections.
- When keys required to decrypt an NCA are missing, throw an exception with information about the missing keys.
- Add more sanity checks when reading an NCA.
- Add a cache to prevent validation an IntegrityVerificationStream block twice.
- Add section validation for all hashed NCA sections
- Fix a bug in ConbinationStream when reading across boundaries
- Add option to verify NCAs in a SwitchFS or SD card
- Don't error if the an patch NCA's base NCA has no RomFS