### PR TITLE
use BouncyCastle for RSA-PSS Verify on non Windows

### DIFF
--- a/src/LibHac/Crypto.cs
+++ b/src/LibHac/Crypto.cs
@@ -3,6 +3,11 @@ using System.IO;
 using System.Numerics;
 using System.Security.Cryptography;
 using LibHac.IO;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
 
 namespace LibHac
 {
@@ -156,17 +161,36 @@ namespace LibHac
 
         public static Validity Rsa2048PssVerify(byte[] data, byte[] signature, byte[] modulus)
         {
-#if USE_RSA_CNG
-            using (RSA rsa = new RSACng())
-#else
-            using (RSA rsa = RSA.Create())
-#endif
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                rsa.ImportParameters(new RSAParameters { Exponent = new byte[] { 1, 0, 1 }, Modulus = modulus });
+#if USE_RSA_CNG
+                using (RSA rsa = new RSACng())
+#else
+                using (RSA rsa = RSA.Create())
+#endif
+                {
+                    rsa.ImportParameters(new RSAParameters { Exponent = new byte[] { 1, 0, 1 }, Modulus = modulus });
 
-                return rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss)
-                    ? Validity.Valid
-                    : Validity.Invalid;
+                    return rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss)
+                        ? Validity.Valid
+                        : Validity.Invalid;
+                }
+            }
+            else
+            {
+                try
+                {
+                    PssSigner pss = new PssSigner(new RsaEngine(), new Sha256Digest());
+                    pss.Init(false, new RsaKeyParameters(false, new Org.BouncyCastle.Math.BigInteger(1, modulus), new Org.BouncyCastle.Math.BigInteger(1, new byte[] { 1, 0, 1 })));
+                    pss.BlockUpdate(data, 0, data.Length);
+                    return pss.VerifySignature(signature)
+                        ? Validity.Valid
+                        : Validity.Invalid;
+                }
+                catch (DataLengthException)
+                {
+                    return Validity.Unchecked;
+                }
             }
         }
 

--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="BouncyCastle.Crypto.dll" Version="1.8.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR allow the use of RSA-PSS on non Windows by using BouncyCastle Crypto library instead of RsaCng
Although in some cases `PssSigner.VerifySignature` still fails with exception `DataLengthException` while trying to verify signature, so it's temporarily fallback to return Validity.Unchecked for now
Close #22 
