### PR TITLE
 Support 6.2.0 keygen and reorder exported keys

### DIFF
--- a/src/LibHac/Nca.cs
+++ b/src/LibHac/Nca.cs
@@ -48,13 +48,13 @@ namespace LibHac
             }
             else if (keyset.TitleKeys.TryGetValue(Header.RightsId, out byte[] titleKey))
             {
-                if (keyset.Titlekeks[CryptoType].IsEmpty())
+                if (keyset.TitleKeks[CryptoType].IsEmpty())
                 {
                     MissingKeyName = $"titlekek_{CryptoType:x2}";
                 }
 
                 TitleKey = titleKey;
-                Crypto.DecryptEcb(keyset.Titlekeks[CryptoType], titleKey, TitleKeyDec, 0x10);
+                Crypto.DecryptEcb(keyset.TitleKeks[CryptoType], titleKey, TitleKeyDec, 0x10);
                 DecryptedKeys[2] = TitleKeyDec;
             }
             else

--- a/src/LibHac/Util.cs
+++ b/src/LibHac/Util.cs
@@ -424,6 +424,8 @@ namespace LibHac
                 case 3: return "4.0.0-4.1.0";
                 case 4: return "5.0.0-5.1.0";
                 case 5: return "6.0.0-6.0.1";
+                case 6: return "6.2.0";
+                case 7: return "7.0.0";
                 default: return "Unknown";
             }
         }


### PR DESCRIPTION
Instead of being ordered alphabetically, exported keys are placed in logical groupings