### PR TITLE
Fix CleanDirectoryRecursivelyGeneric

### DIFF
--- a/src/LibHac/FsSystem/FileSystemExtensions.cs
+++ b/src/LibHac/FsSystem/FileSystemExtensions.cs
@@ -205,7 +205,7 @@ namespace LibHac.FsSystem
         {
             IFileSystem fs = fileSystem;
 
-            foreach (DirectoryEntryEx entry in fileSystem.EnumerateEntries(path, "*"))
+            foreach (DirectoryEntryEx entry in fileSystem.EnumerateEntries(path, "*", SearchOptions.Default))
             {
                 string subPath = PathTools.Combine(path, entry.Name);
 


### PR DESCRIPTION
Fix a bug in `CleanDirectoryRecursivelyGeneric`
Fixes #86 