### PR TITLE
Add Result methods for debugging

### DIFF
--- a/src/LibHac/HorizonResultException.cs
+++ b/src/LibHac/HorizonResultException.cs
@@ -82,10 +82,10 @@ namespace LibHac
             {
                 if (!string.IsNullOrWhiteSpace(InnerMessage))
                 {
-                    return $"{ResultValue.ErrorCode}: {InnerMessage}";
+                    return $"{ResultValue.ToStringWithName()}: {InnerMessage}";
                 }
 
-                return ResultValue.ErrorCode;
+                return ResultValue.ToStringWithName();
             }
         }
     }

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -19,6 +19,7 @@ namespace hactoolnet
             new CliOption("titlekeys", 1, (o, a) => o.TitleKeyFile = a[0]),
             new CliOption("consolekeys", 1, (o, a) => o.ConsoleKeyFile = a[0]),
             new CliOption("accesslog", 1, (o, a) => o.AccessLog = a[0]),
+            new CliOption("resultlog", 1, (o, a) => o.ResultLog = a[0]),
             new CliOption("section0", 1, (o, a) => o.SectionOut[0] = a[0]),
             new CliOption("section1", 1, (o, a) => o.SectionOut[1] = a[0]),
             new CliOption("section2", 1, (o, a) => o.SectionOut[2] = a[0]),

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -16,6 +16,7 @@ namespace hactoolnet
         public string TitleKeyFile;
         public string ConsoleKeyFile;
         public string AccessLog;
+        public string ResultLog;
         public string[] SectionOut = new string[4];
         public string[] SectionOutDir = new string[4];
         public string HeaderOut;

--- a/src/hactoolnet/Program.cs
+++ b/src/hactoolnet/Program.cs
@@ -25,7 +25,7 @@ namespace hactoolnet
 
                 if (ex.ResultValue != ex.InternalResultValue)
                 {
-                    Console.Error.WriteLine($"Internal Code: {ex.InternalResultValue.ErrorCode}");
+                    Console.Error.WriteLine($"Internal Code: {ex.InternalResultValue.ToStringWithName()}");
                 }
 
                 Console.Error.WriteLine();

--- a/src/hactoolnet/Program.cs
+++ b/src/hactoolnet/Program.cs
@@ -52,9 +52,12 @@ namespace hactoolnet
             if (ctx.Options == null) return false;
 
             StreamWriter logWriter = null;
+            StreamWriter resultWriter = null;
 
             try
             {
+                Result.GetResultNameHandler = ResultLogFunctions.TryGetResultName;
+
                 using (var logger = new ProgressBar())
                 {
                     ctx.Logger = logger;
@@ -71,6 +74,15 @@ namespace hactoolnet
                         ctx.Horizon.Fs.SetAccessLogObject(accessLog);
                     }
 
+                    if (ctx.Options.ResultLog != null)
+                    {
+                        resultWriter = new StreamWriter(ctx.Options.ResultLog);
+                        ResultLogFunctions.LogWriter = resultWriter;
+
+                        Result.LogCallback = ResultLogFunctions.LogResult;
+                        Result.ConvertedLogCallback = ResultLogFunctions.LogConvertedResult;
+                    }
+
                     OpenKeyset(ctx);
 
                     if (ctx.Options.RunCustom)
@@ -85,6 +97,9 @@ namespace hactoolnet
             finally
             {
                 logWriter?.Dispose();
+                resultWriter?.Dispose();
+
+                ResultLogFunctions.LogWriter = null;
             }
 
             return true;

--- a/src/hactoolnet/ResultLog.cs
+++ b/src/hactoolnet/ResultLog.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using LibHac;
+using LibHac.Fs;
+
+namespace hactoolnet
+{
+    public static class ResultLogFunctions
+    {
+        private static Dictionary<Result, string> ResultNames { get; } = GetResultNames();
+
+        public static TextWriter LogWriter { get; set; }
+
+        public static void LogResult(Result result)
+        {
+            if (LogWriter == null) return;
+
+            var st = new StackTrace(2, true);
+
+            if (st.FrameCount > 1)
+            {
+                MethodBase method = st.GetFrame(0).GetMethod();
+
+                // This result from these functions is usually noise because they
+                // are frequently used to detect if a file exists
+                if (result == ResultFs.PathNotFound &&
+                    typeof(IFileSystem).IsAssignableFrom(method.DeclaringType) &&
+                    method.Name.StartsWith(nameof(IFileSystem.GetEntryType)) ||
+                    method.Name.StartsWith(nameof(IAttributeFileSystem.GetFileAttributes)))
+                {
+                   // return;
+                }
+
+                string methodName = $"{method.DeclaringType?.FullName}.{method.Name}";
+
+                LogWriter.WriteLine($"{result.ToStringWithName()} returned by {methodName}");
+                LogWriter.WriteLine(st);
+            }
+        }
+
+        public static void LogConvertedResult(Result result, Result originalResult)
+        {
+            if (LogWriter == null) return;
+
+            var st = new StackTrace(2, false);
+
+            if (st.FrameCount > 1)
+            {
+                MethodBase method = st.GetFrame(0).GetMethod();
+
+                string methodName = $"{method.DeclaringType?.FullName}.{method.Name}";
+
+                LogWriter.WriteLine($"{originalResult.ToStringWithName()} was converted to {result.ToStringWithName()} by {methodName}");
+            }
+        }
+
+        public static Dictionary<Result, string> GetResultNames()
+        {
+            var dict = new Dictionary<Result, string>();
+
+            Assembly assembly = typeof(Result).Assembly;
+
+            foreach (Type type in assembly.GetTypes().Where(x => x.Name.Contains("Result")))
+            {
+                foreach (PropertyInfo property in type.GetProperties()
+                    .Where(x => x.PropertyType == typeof(Result) && x.GetMethod.IsStatic && x.SetMethod == null))
+                {
+                    var value = (Result)property.GetValue(null, null);
+                    string name = $"{type.Name}{property.Name}";
+
+                    dict.Add(value, name);
+                }
+            }
+
+            return dict;
+        }
+
+        public static bool TryGetResultName(Result result, out string name)
+        {
+            return ResultNames.TryGetValue(result, out name);
+        }
+    }
+}


### PR DESCRIPTION
Allow setting a callback function for when Result.Log is called.
Allow setting a function that returns a name for a Result value.
Print Result name in error messages.