### PR TITLE
Ensure result codes are logged, and improve some error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,4 @@ __pycache__/
 global.json
 
 !tests/LibHac.Tests/CryptoTests/TestVectors/*
+**/DisasmoBin/

--- a/src/LibHac/Common/HResult.cs
+++ b/src/LibHac/Common/HResult.cs
@@ -20,25 +20,22 @@ namespace LibHac.Common
         public const int ERROR_DIRECTORY = unchecked((int)0x8007010B);
         public const int ERROR_SPACES_NOT_ENOUGH_DRIVES = unchecked((int)0x80E7000B);
 
-        public static Result HResultToHorizonResult(int hResult)
+        public static Result HResultToHorizonResult(int hResult) => hResult switch
         {
-            return hResult switch
-            {
-                ERROR_FILE_NOT_FOUND => ResultFs.PathNotFound,
-                ERROR_PATH_NOT_FOUND => ResultFs.PathNotFound,
-                ERROR_ACCESS_DENIED => ResultFs.TargetLocked,
-                ERROR_SHARING_VIOLATION => ResultFs.TargetLocked,
-                ERROR_HANDLE_EOF => ResultFs.ValueOutOfRange,
-                ERROR_HANDLE_DISK_FULL => ResultFs.InsufficientFreeSpace,
-                ERROR_FILE_EXISTS => ResultFs.PathAlreadyExists,
-                ERROR_DISK_FULL => ResultFs.InsufficientFreeSpace,
-                ERROR_INVALID_NAME => ResultFs.PathNotFound,
-                ERROR_DIR_NOT_EMPTY => ResultFs.DirectoryNotEmpty,
-                ERROR_ALREADY_EXISTS => ResultFs.PathAlreadyExists,
-                ERROR_DIRECTORY => ResultFs.PathNotFound,
-                ERROR_SPACES_NOT_ENOUGH_DRIVES => ResultFs.InsufficientFreeSpace,
-                _ => ResultFs.UnknownHostFileSystemError
-            };
-        }
+            ERROR_FILE_NOT_FOUND => ResultFs.PathNotFound,
+            ERROR_PATH_NOT_FOUND => ResultFs.PathNotFound,
+            ERROR_ACCESS_DENIED => ResultFs.TargetLocked,
+            ERROR_SHARING_VIOLATION => ResultFs.TargetLocked,
+            ERROR_HANDLE_EOF => ResultFs.ValueOutOfRange,
+            ERROR_HANDLE_DISK_FULL => ResultFs.InsufficientFreeSpace,
+            ERROR_FILE_EXISTS => ResultFs.PathAlreadyExists,
+            ERROR_DISK_FULL => ResultFs.InsufficientFreeSpace,
+            ERROR_INVALID_NAME => ResultFs.PathNotFound,
+            ERROR_DIR_NOT_EMPTY => ResultFs.DirectoryNotEmpty,
+            ERROR_ALREADY_EXISTS => ResultFs.PathAlreadyExists,
+            ERROR_DIRECTORY => ResultFs.PathNotFound,
+            ERROR_SPACES_NOT_ENOUGH_DRIVES => ResultFs.InsufficientFreeSpace,
+            _ => ResultFs.UnknownHostFileSystemError
+        };
     }
 }

--- a/src/LibHac/Fs/Accessors/FileSystemAccessor.cs
+++ b/src/LibHac/Fs/Accessors/FileSystemAccessor.cs
@@ -151,7 +151,7 @@ namespace LibHac.Fs.Accessors
 
         public Result GetCommonMountName(Span<byte> nameBuffer)
         {
-            if (MountNameGenerator == null) return ResultFs.PreconditionViolation;
+            if (MountNameGenerator == null) return ResultFs.PreconditionViolation.Log();
 
             return MountNameGenerator.GenerateCommonMountName(nameBuffer);
         }

--- a/src/LibHac/Fs/Accessors/MountTable.cs
+++ b/src/LibHac/Fs/Accessors/MountTable.cs
@@ -16,7 +16,7 @@ namespace LibHac.Fs.Accessors
 
                 if (Table.ContainsKey(mountName))
                 {
-                    return ResultFs.MountNameAlreadyExists;
+                    return ResultFs.MountNameAlreadyExists.Log();
                 }
 
                 Table.Add(mountName, fileSystem);
@@ -31,7 +31,7 @@ namespace LibHac.Fs.Accessors
             {
                 if (!Table.TryGetValue(name, out fileSystem))
                 {
-                    return ResultFs.MountNameNotFound;
+                    return ResultFs.MountNameNotFound.Log();
                 }
 
                 return Result.Success;
@@ -44,7 +44,7 @@ namespace LibHac.Fs.Accessors
             {
                 if (!Table.TryGetValue(name, out FileSystemAccessor fsAccessor))
                 {
-                    return ResultFs.MountNameNotFound;
+                    return ResultFs.MountNameNotFound.Log();
                 }
 
                 Table.Remove(name);

--- a/src/LibHac/FsService/Creators/EmulatedBisFileSystemCreator.cs
+++ b/src/LibHac/FsService/Creators/EmulatedBisFileSystemCreator.cs
@@ -22,8 +22,8 @@ namespace LibHac.FsService.Creators
         {
             fileSystem = default;
 
-            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument;
-            if (rootPath == null) return ResultFs.NullArgument;
+            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument.Log();
+            if (rootPath == null) return ResultFs.NullArgument.Log();
 
             if (Config.TryGetFileSystem(out fileSystem, partitionId))
             {
@@ -32,7 +32,7 @@ namespace LibHac.FsService.Creators
 
             if (Config.RootFileSystem == null)
             {
-                return ResultFs.PreconditionViolation;
+                return ResultFs.PreconditionViolation.Log();
             }
 
             string partitionPath = GetPartitionPath(partitionId);
@@ -54,7 +54,7 @@ namespace LibHac.FsService.Creators
         public Result CreateFatFileSystem(out IFileSystem fileSystem, BisPartitionId partitionId)
         {
             fileSystem = default;
-            return ResultFs.NotImplemented;
+            return ResultFs.NotImplemented.Log();
         }
 
         public Result SetBisRootForHost(BisPartitionId partitionId, string rootPath)

--- a/src/LibHac/FsService/Creators/EmulatedBisFileSystemCreatorConfig.cs
+++ b/src/LibHac/FsService/Creators/EmulatedBisFileSystemCreatorConfig.cs
@@ -14,8 +14,8 @@ namespace LibHac.FsService.Creators
 
         public Result SetFileSystem(IFileSystem fileSystem, BisPartitionId partitionId)
         {
-            if (fileSystem == null) return ResultFs.NullArgument;
-            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument;
+            if (fileSystem == null) return ResultFs.NullArgument.Log();
+            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument.Log();
 
             PartitionFileSystems[GetArrayIndex(partitionId)] = fileSystem;
 
@@ -24,8 +24,8 @@ namespace LibHac.FsService.Creators
 
         public Result SetPath(string path, BisPartitionId partitionId)
         {
-            if (path == null) return ResultFs.NullArgument;
-            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument;
+            if (path == null) return ResultFs.NullArgument.Log();
+            if (!IsValidPartitionId(partitionId)) return ResultFs.InvalidArgument.Log();
 
             PartitionPaths[GetArrayIndex(partitionId)] = path;
 

--- a/src/LibHac/FsService/Creators/EncryptedFileSystemCreator.cs
+++ b/src/LibHac/FsService/Creators/EncryptedFileSystemCreator.cs
@@ -20,7 +20,7 @@ namespace LibHac.FsService.Creators
 
             if (keyId < EncryptedFsKeyId.Save || keyId > EncryptedFsKeyId.CustomStorage)
             {
-                return ResultFs.InvalidArgument;
+                return ResultFs.InvalidArgument.Log();
             }
 
             // todo: "proper" key generation instead of a lazy hack

--- a/src/LibHac/FsService/Creators/SaveDataFileSystemCreator.cs
+++ b/src/LibHac/FsService/Creators/SaveDataFileSystemCreator.cs
@@ -32,7 +32,7 @@ namespace LibHac.FsService.Creators
             Result rc = sourceFileSystem.GetEntryType(out DirectoryEntryType entryType, saveDataPath);
             if (rc.IsFailure())
             {
-                return rc == ResultFs.PathNotFound ? ResultFs.TargetNotFound : rc;
+                return rc == ResultFs.PathNotFound ? ResultFs.TargetNotFound.LogConverted(rc) : rc;
             }
 
             switch (entryType)

--- a/src/LibHac/FsService/FileSystemProxy.cs
+++ b/src/LibHac/FsService/FileSystemProxy.cs
@@ -514,7 +514,12 @@ namespace LibHac.FsService
                 }
             }
 
-            return ResultFs.TargetNotFound;
+            if (saveFsResult == ResultFs.PathNotFound)
+            {
+                return ResultFs.TargetNotFound.LogConverted(saveFsResult);
+            }
+
+            return saveFsResult;
         }
 
         private Result OpenSaveDataFileSystem3(out IFileSystem fileSystem, SaveDataSpaceId spaceId,
@@ -873,7 +878,7 @@ namespace LibHac.FsService
         {
             if (saveDataSize < 0 || saveDataJournalSize < 0)
             {
-                return ResultFs.InvalidSize;
+                return ResultFs.InvalidSize.Log();
             }
 
             SaveDataSize = saveDataSize;
@@ -887,7 +892,7 @@ namespace LibHac.FsService
 
             if (StringUtils.GetLength(path.Str, FsPath.MaxLength + 1) > FsPath.MaxLength)
             {
-                return ResultFs.TooLongPath;
+                return ResultFs.TooLongPath.Log();
             }
 
             StringUtils.Copy(SaveDataRootPath.Str, path.Str);
@@ -971,7 +976,7 @@ namespace LibHac.FsService
         public Result SetSdCardEncryptionSeed(ReadOnlySpan<byte> seed)
         {
             // todo: use struct instead of byte span
-            if (seed.Length != 0x10) return ResultFs.InvalidSize;
+            if (seed.Length != 0x10) return ResultFs.InvalidSize.Log();
 
             // Missing permission check
 

--- a/src/LibHac/FsService/FileSystemProxyCore.cs
+++ b/src/LibHac/FsService/FileSystemProxyCore.cs
@@ -85,7 +85,7 @@ namespace LibHac.FsService
                     isEncrypted = true;
                     break;
                 default:
-                    rc = ResultFs.InvalidArgument;
+                    rc = ResultFs.InvalidArgument.Log();
                     break;
             }
 

--- a/src/LibHac/FsSystem/FsPath.cs
+++ b/src/LibHac/FsSystem/FsPath.cs
@@ -27,7 +27,7 @@ namespace LibHac.FsSystem
 
             U8StringBuilder builder = new U8StringBuilder(fsPath.Str).Append(path);
 
-            return builder.Overflowed ? ResultFs.TooLongPath : Result.Success;
+            return builder.Overflowed ? ResultFs.TooLongPath.Log() : Result.Success;
         }
 
         public static implicit operator U8Span(FsPath value) => new U8Span(value.Str);

--- a/src/LibHac/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/FsSystem/NcaUtils/Nca.cs
@@ -48,9 +48,11 @@ namespace LibHac.FsSystem.NcaUtils
             int keyRevision = Util.GetMasterKeyRevision(Header.KeyGeneration);
             byte[] titleKek = Keyset.TitleKeks[keyRevision];
 
-            if (Keyset.ExternalKeySet.Get(new RightsId(Header.RightsId), out AccessKey accessKey).IsFailure())
+            var rightsId = new RightsId(Header.RightsId);
+
+            if (Keyset.ExternalKeySet.Get(rightsId, out AccessKey accessKey).IsFailure())
             {
-                throw new MissingKeyException("Missing NCA title key.", Header.RightsId.ToString(), KeyType.Title);
+                throw new MissingKeyException("Missing NCA title key.", rightsId.ToString(), KeyType.Title);
             }
 
             if (titleKek.IsEmpty())

--- a/src/LibHac/FsSystem/PartitionFileSystemMetaCore.cs
+++ b/src/LibHac/FsSystem/PartitionFileSystemMetaCore.cs
@@ -156,12 +156,12 @@ namespace LibHac.FsSystem
         {
             if (typeof(T) == typeof(StandardEntry))
             {
-                return ResultFs.InvalidPartitionFileSystemMagic;
+                return ResultFs.InvalidPartitionFileSystemMagic.Log();
             }
 
             if (typeof(T) == typeof(HashedEntry))
             {
-                return ResultFs.InvalidHashedPartitionFileSystemMagic;
+                return ResultFs.InvalidHashedPartitionFileSystemMagic.Log();
             }
 
             throw new NotSupportedException();

--- a/src/LibHac/FsSystem/Save/SaveDataFileSystem.cs
+++ b/src/LibHac/FsSystem/Save/SaveDataFileSystem.cs
@@ -147,98 +147,98 @@ namespace LibHac.FsSystem.Save
         {
             Result result = SaveDataFileSystemCore.CreateDirectory(path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result CreateFileImpl(string path, long size, CreateFileOptions options)
         {
             Result result = SaveDataFileSystemCore.CreateFile(path, size, options);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result DeleteDirectoryImpl(string path)
         {
             Result result = SaveDataFileSystemCore.DeleteDirectory(path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result DeleteDirectoryRecursivelyImpl(string path)
         {
             Result result = SaveDataFileSystemCore.DeleteDirectoryRecursively(path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result CleanDirectoryRecursivelyImpl(string path)
         {
             Result result = SaveDataFileSystemCore.CleanDirectoryRecursively(path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result DeleteFileImpl(string path)
         {
             Result result = SaveDataFileSystemCore.DeleteFile(path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result OpenDirectoryImpl(out IDirectory directory, string path, OpenDirectoryMode mode)
         {
             Result result = SaveDataFileSystemCore.OpenDirectory(out directory, path, mode);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result OpenFileImpl(out IFile file, string path, OpenMode mode)
         {
             Result result = SaveDataFileSystemCore.OpenFile(out file, path, mode);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result RenameDirectoryImpl(string oldPath, string newPath)
         {
             Result result = SaveDataFileSystemCore.RenameDirectory(oldPath, newPath);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result RenameFileImpl(string oldPath, string newPath)
         {
             Result result = SaveDataFileSystemCore.RenameFile(oldPath, newPath);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result GetEntryTypeImpl(out DirectoryEntryType entryType, string path)
         {
             Result result = SaveDataFileSystemCore.GetEntryType(out entryType, path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result GetFreeSpaceSizeImpl(out long freeSpace, string path)
         {
             Result result = SaveDataFileSystemCore.GetFreeSpaceSize(out freeSpace, path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result GetTotalSpaceSizeImpl(out long totalSpace, string path)
         {
             Result result = SaveDataFileSystemCore.GetTotalSpaceSize(out totalSpace, path);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         protected override Result CommitImpl()
         {
             Result result = Commit(Keyset);
 
-            return SaveResults.ConvertToExternalResult(result);
+            return SaveResults.ConvertToExternalResult(result).LogConverted(result);
         }
 
         public Result Commit(Keyset keyset)
@@ -259,7 +259,7 @@ namespace LibHac.FsSystem.Save
             headerStream.Position = 0x108;
             headerStream.Write(hash, 0, hash.Length);
 
-            if (keyset == null || keyset.SaveMacKey.IsEmpty()) return ResultFs.PreconditionViolation;
+            if (keyset == null || keyset.SaveMacKey.IsEmpty()) return ResultFs.PreconditionViolation.Log();
 
             var cmacData = new byte[0x200];
             var cmac = new byte[0x10];

--- a/src/LibHac/FsSystem/Save/SaveResults.cs
+++ b/src/LibHac/FsSystem/Save/SaveResults.cs
@@ -87,7 +87,7 @@ namespace LibHac.FsSystem.Save
             {
                 if (description > 4721 && description < 4729)
                 {
-                    return new Result(ResultFs.ModuleFs, (description - 260));
+                    return new Result(ResultFs.ModuleFs, description - 260);
                 }
 
                 return result;

--- a/src/LibHac/Result.cs
+++ b/src/LibHac/Result.cs
@@ -42,9 +42,8 @@ namespace LibHac
         /// <returns>The called <see cref="Result"/> value.</returns>
         public Result Log()
         {
-#if DEBUG
-            LogCallback?.Invoke(this);
-#endif
+            LogImpl();
+
             return this;
         }
 
@@ -55,10 +54,21 @@ namespace LibHac
         /// <returns>The called <see cref="Result"/> value.</returns>
         public Result LogConverted(Result originalResult)
         {
-#if DEBUG
-            ConvertedLogCallback?.Invoke(this, originalResult);
-#endif
+            LogConvertedImpl(originalResult);
+
             return this;
+        }
+
+        [Conditional("DEBUG")]
+        private void LogImpl()
+        {
+            LogCallback?.Invoke(this);
+        }
+
+        [Conditional("DEBUG")]
+        private void LogConvertedImpl(Result originalResult)
+        {
+            ConvertedLogCallback?.Invoke(this, originalResult);
         }
 
         public delegate void ResultLogger(Result result);

--- a/src/hactoolnet/ProcessSave.cs
+++ b/src/hactoolnet/ProcessSave.cs
@@ -103,7 +103,15 @@ namespace hactoolnet
                 {
                     if (signNeeded)
                     {
-                        save.Commit(ctx.Keyset).ThrowIfFailure();
+                        if (save.Commit(ctx.Keyset).IsSuccess())
+                        {
+                            ctx.Logger.LogMessage("Successfully signed save file");
+                        }
+                        else
+                        {
+                            ctx.Logger.LogMessage("Unable to sign save file. Do you have all the required keys?");
+                        }
+
                         signNeeded = false;
                     }
                 }


### PR DESCRIPTION
- Make sure `Result.Log()` is called when returning non-success results.
- Return a message indicating keys may be missing when a commit fails after replacing files in a save.
- Properly display the rights ID when missing a title key.