### PR TITLE
Implement Encrypt function in NCA class to re-encrypt decrypted NCAs

### DIFF
--- a/src/LibHac/FsSystem/Aes128XtsStorage.cs
+++ b/src/LibHac/FsSystem/Aes128XtsStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using LibHac.Fs;
 
 namespace LibHac.FsSystem
@@ -9,24 +9,27 @@ namespace LibHac.FsSystem
 
         private readonly byte[] _tempBuffer;
 
-        private Aes128XtsTransform _decryptor;
-        private Aes128XtsTransform _encryptor;
+        private Aes128XtsTransform _readTransform;
+        private Aes128XtsTransform _writeTransform;
 
         private readonly byte[] _key1;
         private readonly byte[] _key2;
 
-        public Aes128XtsStorage(IStorage baseStorage, Span<byte> key, int sectorSize, bool leaveOpen)
+        private readonly bool _decryptRead;
+
+        public Aes128XtsStorage(IStorage baseStorage, Span<byte> key, int sectorSize, bool leaveOpen, bool decryptRead = true)
             : base(baseStorage, sectorSize, leaveOpen)
         {
             if (key == null) throw new NullReferenceException(nameof(key));
             if (key.Length != BlockSize * 2) throw new ArgumentException(nameof(key), $"Key must be {BlockSize * 2} bytes long");
 
             _tempBuffer = new byte[sectorSize];
+            _decryptRead = decryptRead;
             _key1 = key.Slice(0, BlockSize).ToArray();
             _key2 = key.Slice(BlockSize, BlockSize).ToArray();
         }
 
-        public Aes128XtsStorage(IStorage baseStorage, Span<byte> key1, Span<byte> key2, int sectorSize, bool leaveOpen)
+        public Aes128XtsStorage(IStorage baseStorage, Span<byte> key1, Span<byte> key2, int sectorSize, bool leaveOpen, bool decryptRead = true)
             : base(baseStorage, sectorSize, leaveOpen)
         {
             if (key1 == null) throw new NullReferenceException(nameof(key1));
@@ -34,6 +37,7 @@ namespace LibHac.FsSystem
             if (key1.Length != BlockSize || key1.Length != BlockSize) throw new ArgumentException($"Keys must be {BlockSize} bytes long");
 
             _tempBuffer = new byte[sectorSize];
+            _decryptRead = decryptRead;
             _key1 = key1.ToArray();
             _key2 = key2.ToArray();
         }
@@ -43,12 +47,12 @@ namespace LibHac.FsSystem
             int size = destination.Length;
             long sectorIndex = offset / SectorSize;
 
-            if (_decryptor == null) _decryptor = new Aes128XtsTransform(_key1, _key2, true);
+            if (_readTransform == null) _readTransform = new Aes128XtsTransform(_key1, _key2, _decryptRead);
 
             Result rc = base.DoRead(offset, _tempBuffer.AsSpan(0, size));
             if (rc.IsFailure()) return rc;
 
-            _decryptor.TransformBlock(_tempBuffer, 0, size, (ulong)sectorIndex);
+            _readTransform.TransformBlock(_tempBuffer, 0, size, (ulong)sectorIndex);
             _tempBuffer.AsSpan(0, size).CopyTo(destination);
 
             return Result.Success;
@@ -59,10 +63,10 @@ namespace LibHac.FsSystem
             int size = source.Length;
             long sectorIndex = offset / SectorSize;
 
-            if (_encryptor == null) _encryptor = new Aes128XtsTransform(_key1, _key2, false);
+            if (_writeTransform == null) _writeTransform = new Aes128XtsTransform(_key1, _key2, !_decryptRead);
 
             source.CopyTo(_tempBuffer);
-            _encryptor.TransformBlock(_tempBuffer, 0, size, (ulong)sectorIndex);
+            _writeTransform.TransformBlock(_tempBuffer, 0, size, (ulong)sectorIndex);
 
             return base.DoWrite(offset, _tempBuffer.AsSpan(0, size));
         }

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -38,6 +38,7 @@ namespace hactoolnet
             new CliOption("outdir", 1, (o, a) => o.OutDir = a[0]),
             new CliOption("outfile", 1, (o, a) => o.OutFile = a[0]),
             new CliOption("plaintext", 1, (o, a) => o.PlaintextOut = a[0]),
+            new CliOption("ciphertext", 1, (o, a) => o.CiphertextOut = a[0]),
             new CliOption("uncompressed", 1, (o, a) => o.UncompressedOut = a[0]),
             new CliOption("nspout", 1, (o, a) => o.NspOut = a[0]),
             new CliOption("sdseed", 1, (o, a) => o.SdSeed = a[0]),
@@ -207,6 +208,7 @@ namespace hactoolnet
             sb.AppendLine("  --accesslog <file>   Specify the access log file path.");
             sb.AppendLine("NCA options:");
             sb.AppendLine("  --plaintext <file>   Specify file path for saving a decrypted copy of the NCA.");
+            sb.AppendLine("  --ciphertext <file>  Specify file path for saving an encrypted copy of the NCA.");
             sb.AppendLine("  --header <file>      Specify Header file path.");
             sb.AppendLine("  --section0 <file>    Specify Section 0 file path.");
             sb.AppendLine("  --section1 <file>    Specify Section 1 file path.");

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -30,6 +30,7 @@ namespace hactoolnet
         public string OutDir;
         public string OutFile;
         public string PlaintextOut;
+        public string CiphertextOut;
         public string UncompressedOut;
         public string SdSeed;
         public string NspOut;

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -170,6 +170,11 @@ namespace hactoolnet
                     nca.OpenDecryptedNca().WriteAllBytes(ctx.Options.PlaintextOut, ctx.Logger);
                 }
 
+                if (ctx.Options.CiphertextOut != null)
+                {
+                    nca.OpenEncryptedNca().WriteAllBytes(ctx.Options.CiphertextOut, ctx.Logger);
+                }
+
                 if (!ctx.Options.ReadBench) ctx.Logger.LogMessage(ncaHolder.Print());
 
                 IStorage OpenStorage(int index)


### PR DESCRIPTION
I've tested a re-encrypt with Ryujinx and it works the same as the original NCA. However the operation is not completely lossless, the bits between offsets 0xC00-0x4000 are zero in both the NCA decrypted by the OpenDecryptedNca() function and the re-encrypted NCA.