### PR TITLE
Support NCA0 sections using IVFC hashes

### DIFF
--- a/src/LibHac/FsSystem/NcaUtils/NcaExtensions.cs
+++ b/src/LibHac/FsSystem/NcaUtils/NcaExtensions.cs
@@ -97,6 +97,12 @@ namespace LibHac.FsSystem.NcaUtils
 
             IStorage storage = nca.OpenRawStorage(index);
 
+            // The FS header of an NCA0 section with IVFC verification must be manually skipped
+            if (nca.Header.IsNca0() && header.HashType == NcaHashType.Ivfc)
+            {
+                offset += 0x200;
+            }
+
             var data = new byte[size];
             storage.Read(offset, data).ThrowIfFailure();
 


### PR DESCRIPTION
The offsets in the IVFC info don't account for the additional 0x200 bytes the FS header takes up at the beginning of the section. These 0x200 bytes need to be manually skipped.