### PR TITLE
Adds BufferedStorage and supporting classes

### DIFF
--- a/build/CodeGen/results.csv
+++ b/build/CodeGen/results.csv
@@ -109,6 +109,7 @@ Module,DescriptionStart,DescriptionEnd,Name,Summary
 2,3383,,AllocationFailureInAesXtsFileE,In Initialize
 2,3394,,AllocationFailureInEncryptedFileSystemCreatorA,In Create allocating AesXtsFileSystem
 2,3407,,AllocationFailureInFileSystemInterfaceAdapter, In OpenFile or OpenDirectory
+2,3411,,AllocationFailureInBufferedStorageA, In Initialize allocating Cache array
 2,3420,,AllocationFailureInNew,
 2,3421,,AllocationFailureInCreateShared,
 2,3422,,AllocationFailureInMakeUnique,

--- a/build/CodeGen/results.csv
+++ b/build/CodeGen/results.csv
@@ -94,6 +94,8 @@ Module,DescriptionStart,DescriptionEnd,Name,Summary
 2,3258,,AllocationFailureInProgramRegistryManagerA,In RegisterProgram allocating ProgramInfoNode
 2,3264,,AllocationFailureFatFileSystemA,In Initialize allocating ProgramInfoNode
 2,3280,,AllocationFailureInPartitionFileSystemCreatorA,In Create allocating PartitionFileSystemCore
+2,3294,,AllocationFailureInFileSystemBuddyHeapA,In Initialize allocating free areas array
+2,3295,,AllocationFailureInFileSystemBufferManagerA,In CacheHandleTable::Initialize allocating an entry buffer
 2,3312,,AllocationFailureInAesXtsFileA,In Initialize allocating FileStorage
 2,3313,,AllocationFailureInAesXtsFileB,In Initialize allocating AesXtsStorage
 2,3314,,AllocationFailureInAesXtsFileC,In Initialize allocating AlignmentMatchingStoragePooledBuffer

--- a/src/LibHac/Boot/Package1.cs
+++ b/src/LibHac/Boot/Package1.cs
@@ -340,7 +340,7 @@ namespace LibHac.Boot
             int pk11Size = Unsafe.SizeOf<Package1Pk11Header>() + GetSectionSize(Package1Section.WarmBoot) +
                     GetSectionSize(Package1Section.Bootloader) + GetSectionSize(Package1Section.SecureMonitor);
 
-            pk11Size = Utilities.AlignUp(pk11Size, 0x10);
+            pk11Size = Alignment.AlignUp(pk11Size, 0x10);
 
             return pk11Size == Pk11Size;
         }

--- a/src/LibHac/Boot/Package1.cs
+++ b/src/LibHac/Boot/Package1.cs
@@ -335,7 +335,7 @@ namespace LibHac.Boot
 
         private bool VerifyPk11Sizes()
         {
-            Assert.AssertTrue(IsDecrypted);
+            Assert.True(IsDecrypted);
 
             int pk11Size = Unsafe.SizeOf<Package1Pk11Header>() + GetSectionSize(Package1Section.WarmBoot) +
                     GetSectionSize(Package1Section.Bootloader) + GetSectionSize(Package1Section.SecureMonitor);

--- a/src/LibHac/Common/Keys/ExternalKeyReader.cs
+++ b/src/LibHac/Common/Keys/ExternalKeyReader.cs
@@ -493,8 +493,8 @@ namespace LibHac.Common.Keys
             // of the file which will be treated as the end of a line.
             if (state == ReaderState.Value || state == ReaderState.WhiteSpace2)
             {
-                Assert.AssertTrue(i == buffer.Length);
-                Assert.AssertTrue(reader.HasReadEndOfFile);
+                Assert.True(i == buffer.Length);
+                Assert.True(reader.HasReadEndOfFile);
 
                 // WhiteSpace2 will have already set this value
                 if (state == ReaderState.Value)
@@ -506,8 +506,8 @@ namespace LibHac.Common.Keys
             // Same situation as the two above states
             if (state == ReaderState.Comment)
             {
-                Assert.AssertTrue(i == buffer.Length);
-                Assert.AssertTrue(reader.HasReadEndOfFile);
+                Assert.True(i == buffer.Length);
+                Assert.True(reader.HasReadEndOfFile);
 
                 keyLength = i - keyOffset;
                 state = ReaderState.CommentSuccess;
@@ -516,8 +516,8 @@ namespace LibHac.Common.Keys
             // Same as the above states except the final line was empty or whitespace.
             if (state == ReaderState.Initial)
             {
-                Assert.AssertTrue(i == buffer.Length);
-                Assert.AssertTrue(reader.HasReadEndOfFile);
+                Assert.True(i == buffer.Length);
+                Assert.True(reader.HasReadEndOfFile);
 
                 reader.BufferPos = i;
                 return ReaderStatus.NoKeyRead;

--- a/src/LibHac/Common/Keys/KeyInfo.cs
+++ b/src/LibHac/Common/Keys/KeyInfo.cs
@@ -48,7 +48,7 @@ namespace LibHac.Common.Keys
 
         public KeyInfo(int group, KeyType type, string name, KeyGetter retrieveFunc)
         {
-            Assert.AssertTrue(IsKeyTypeValid(type));
+            Assert.True(IsKeyTypeValid(type));
 
             Name = name;
             RangeType = KeyRangeType.Single;
@@ -61,7 +61,7 @@ namespace LibHac.Common.Keys
 
         public KeyInfo(int group, KeyType type, string name, byte rangeStart, byte rangeEnd, KeyGetter retrieveFunc)
         {
-            Assert.AssertTrue(IsKeyTypeValid(type));
+            Assert.True(IsKeyTypeValid(type));
 
             Name = name;
             RangeType = KeyRangeType.Range;

--- a/src/LibHac/Common/Ref.cs
+++ b/src/LibHac/Common/Ref.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace LibHac.Common
+{
+    /// <summary>
+    /// A <see langword="struct"/> that can store a reference to a value of a specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of value to reference.</typeparam>
+    public readonly ref struct Ref<T>
+    {
+        /// <summary>
+        /// The 1-length <see cref="Span{T}"/> instance used to track the target <typeparamref name="T"/> value.
+        /// </summary>
+        private readonly Span<T> _span;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ref{T}"/> struct.
+        /// </summary>
+        /// <param name="value">The reference to the target <typeparamref name="T"/> value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Ref(ref T value)
+        {
+            _span = MemoryMarshal.CreateSpan(ref value, 1);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ref{T}"/> struct.
+        /// </summary>
+        /// <param name="pointer">The pointer to the target value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe Ref(void* pointer)
+            : this(ref Unsafe.AsRef<T>(pointer))
+        {
+        }
+
+        /// <summary>
+        /// Gets the <typeparamref name="T"/> reference represented by the current <see cref="Ref{T}"/> instance.
+        /// </summary>
+        public ref T Value
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ref MemoryMarshal.GetReference(_span);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="Ref{T}"/> is <see langword="null"/>.
+        /// </summary>
+        /// <returns><see langword="true"/> if the held reference is <see langword="null"/>;
+        /// otherwise <see langword="false"/>.</returns>
+        public bool IsNull
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Unsafe.IsNullRef(ref Value);
+        }
+
+        /// <summary>
+        /// Implicitly gets the <typeparamref name="T"/> value from a given <see cref="Ref{T}"/> instance.
+        /// </summary>
+        /// <param name="reference">The input <see cref="Ref{T}"/> instance.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator T(Ref<T> reference)
+        {
+            return reference.Value;
+        }
+    }
+}

--- a/src/LibHac/Crypto/Aes.cs
+++ b/src/LibHac/Crypto/Aes.cs
@@ -296,7 +296,7 @@ namespace LibHac.Crypto
 
         private static void LeftShiftBytes(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Assert.AssertTrue(output.Length >= input.Length);
+            Assert.True(output.Length >= input.Length);
 
             byte carry = 0;
 

--- a/src/LibHac/Crypto/Detail/AesCtrMode.cs
+++ b/src/LibHac/Crypto/Detail/AesCtrMode.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using LibHac.Common;
+using LibHac.Util;
 
 namespace LibHac.Crypto.Detail
 {
@@ -25,7 +26,7 @@ namespace LibHac.Crypto.Detail
 
         public void Transform(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            int blockCount = Utilities.DivideByRoundUp(input.Length, Aes.BlockSize);
+            int blockCount = BitUtil.DivideUp(input.Length, Aes.BlockSize);
             int length = blockCount * Aes.BlockSize;
 
             using var counterBuffer = new RentedArray<byte>(length);

--- a/src/LibHac/Diag/Assert.cs
+++ b/src/LibHac/Diag/Assert.cs
@@ -21,6 +21,20 @@ namespace LibHac.Diag
         }
 
         [Conditional("DEBUG")]
+        public static void False([DoesNotReturnIf(true)] bool condition, string message = null)
+        {
+            if (!condition)
+                return;
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new LibHacException("Assertion failed.");
+            }
+
+            throw new LibHacException($"Assertion failed: {message}");
+        }
+
+        [Conditional("DEBUG")]
         public static void Null<T>([NotNull] T item) where T : class
         {
             if (!(item is null))

--- a/src/LibHac/Diag/Assert.cs
+++ b/src/LibHac/Diag/Assert.cs
@@ -7,7 +7,7 @@ namespace LibHac.Diag
     public static class Assert
     {
         [Conditional("DEBUG")]
-        public static void AssertTrue([DoesNotReturnIf(false)] bool condition, string message = null)
+        public static void True([DoesNotReturnIf(false)] bool condition, string message = null)
         {
             if (condition)
                 return;

--- a/src/LibHac/Fs/ApplicationSaveDataManagement.cs
+++ b/src/LibHac/Fs/ApplicationSaveDataManagement.cs
@@ -4,6 +4,7 @@ using LibHac.Account;
 using LibHac.Fs.Shim;
 using LibHac.Ncm;
 using LibHac.Ns;
+using LibHac.Util;
 
 namespace LibHac.Fs
 {
@@ -101,7 +102,7 @@ namespace LibHac.Fs
 
                         if (queryRc.IsFailure()) return queryRc;
 
-                        requiredSizeSum += Utilities.AlignUp(tempSaveTotalSize, 0x4000) + 0x4000;
+                        requiredSizeSum += Alignment.AlignUp(tempSaveTotalSize, 0x4000) + 0x4000;
                     }
                 }
                 else
@@ -118,7 +119,7 @@ namespace LibHac.Fs
 
                             if (queryRc.IsFailure()) return queryRc;
 
-                            requiredSizeSum += Utilities.AlignUp(tempSaveTotalSize, 0x4000) + 0x4000;
+                            requiredSizeSum += Alignment.AlignUp(tempSaveTotalSize, 0x4000) + 0x4000;
                         }
                         else if (ResultFs.PathAlreadyExists.Includes(createRc))
                         {
@@ -162,7 +163,7 @@ namespace LibHac.Fs
                 Result queryRc = fs.QuerySaveDataTotalSize(out long totalSize, dataSize, journalSize);
                 if (queryRc.IsFailure()) return queryRc;
 
-                requiredSize += Utilities.AlignUp(totalSize, 0x4000) + baseSize;
+                requiredSize += Alignment.AlignUp(totalSize, 0x4000) + baseSize;
             }
             else if (!ResultFs.PathAlreadyExists.Includes(rc))
             {

--- a/src/LibHac/Fs/Buffers/Buffer.cs
+++ b/src/LibHac/Fs/Buffers/Buffer.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace LibHac.Fs
+{
+    public readonly struct Buffer
+    {
+        public Memory<byte> Memory { get; }
+        public Span<byte> Span => Memory.Span;
+
+        public Buffer(Memory<byte> buffer)
+        {
+            Memory = buffer;
+        }
+    }
+}

--- a/src/LibHac/Fs/Buffers/Buffer.cs
+++ b/src/LibHac/Fs/Buffers/Buffer.cs
@@ -1,16 +1,28 @@
 ﻿using System;
+using System.ComponentModel;
 
 // ReSharper disable once CheckNamespace
 namespace LibHac.Fs
 {
-    public readonly struct Buffer
+    public readonly struct Buffer : IEquatable<Buffer>
     {
+        public static Buffer Empty => default;
         public Memory<byte> Memory { get; }
         public Span<byte> Span => Memory.Span;
+        public int Length => Memory.Length;
+        public bool IsNull => Memory.IsEmpty;
 
         public Buffer(Memory<byte> buffer)
         {
             Memory = buffer;
         }
+
+        public static bool operator ==(Buffer left, Buffer right) => left.Memory.Equals(right.Memory);
+        public static bool operator !=(Buffer left, Buffer right) => !(left == right);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is Buffer other && Equals(other);
+        public bool Equals(Buffer other) => Memory.Equals(other.Memory);
+        public override int GetHashCode() => Memory.GetHashCode();
     }
 }

--- a/src/LibHac/Fs/Buffers/IBufferManager.cs
+++ b/src/LibHac/Fs/Buffers/IBufferManager.cs
@@ -20,33 +20,33 @@ namespace LibHac.Fs
 
         public const int BufferLevelMin = 0;
 
-        public (UIntPtr address, nuint size) AllocateBuffer(nuint size, BufferAttribute attribute) =>
+        public Buffer AllocateBuffer(int size, BufferAttribute attribute) =>
             DoAllocateBuffer(size, attribute);
 
-        public void DeallocateBuffer(UIntPtr address, nuint size) => DoDeallocateBuffer(address, size);
+        public void DeallocateBuffer(Buffer buffer) => DoDeallocateBuffer(buffer);
 
-        public CacheHandle RegisterCache(UIntPtr address, nuint size, BufferAttribute attribute) =>
-            DoRegisterCache(address, size, attribute);
+        public CacheHandle RegisterCache(Buffer buffer, BufferAttribute attribute) =>
+            DoRegisterCache(buffer, attribute);
 
-        public (UIntPtr address, nuint size) AcquireCache(CacheHandle handle) => DoAcquireCache(handle);
-        public nuint GetTotalSize() => DoGetTotalSize();
-        public nuint GetFreeSize() => DoGetFreeSize();
-        public nuint GetTotalAllocatableSize() => DoGetTotalAllocatableSize();
-        public nuint GetFreeSizePeak() => DoGetFreeSizePeak();
-        public nuint GetTotalAllocatableSizePeak() => DoGetTotalAllocatableSizePeak();
-        public nuint GetRetriedCount() => DoGetRetriedCount();
+        public Buffer AcquireCache(CacheHandle handle) => DoAcquireCache(handle);
+        public int GetTotalSize() => DoGetTotalSize();
+        public int GetFreeSize() => DoGetFreeSize();
+        public int GetTotalAllocatableSize() => DoGetTotalAllocatableSize();
+        public int GetFreeSizePeak() => DoGetFreeSizePeak();
+        public int GetTotalAllocatableSizePeak() => DoGetTotalAllocatableSizePeak();
+        public int GetRetriedCount() => DoGetRetriedCount();
         public void ClearPeak() => DoClearPeak();
 
-        protected abstract (UIntPtr address, nuint size) DoAllocateBuffer(nuint size, BufferAttribute attribute);
-        protected abstract void DoDeallocateBuffer(UIntPtr address, nuint size);
-        protected abstract CacheHandle DoRegisterCache(UIntPtr address, nuint size, BufferAttribute attribute);
-        protected abstract (UIntPtr address, nuint size) DoAcquireCache(CacheHandle handle);
-        protected abstract nuint DoGetTotalSize();
-        protected abstract nuint DoGetFreeSize();
-        protected abstract nuint DoGetTotalAllocatableSize();
-        protected abstract nuint DoGetFreeSizePeak();
-        protected abstract nuint DoGetTotalAllocatableSizePeak();
-        protected abstract nuint DoGetRetriedCount();
+        protected abstract Buffer DoAllocateBuffer(int size, BufferAttribute attribute);
+        protected abstract void DoDeallocateBuffer(Buffer buffer);
+        protected abstract CacheHandle DoRegisterCache(Buffer buffer, BufferAttribute attribute);
+        protected abstract Buffer DoAcquireCache(CacheHandle handle);
+        protected abstract int DoGetTotalSize();
+        protected abstract int DoGetFreeSize();
+        protected abstract int DoGetTotalAllocatableSize();
+        protected abstract int DoGetFreeSizePeak();
+        protected abstract int DoGetTotalAllocatableSizePeak();
+        protected abstract int DoGetRetriedCount();
         protected abstract void DoClearPeak();
 
         protected virtual void Dispose(bool disposing) { }

--- a/src/LibHac/Fs/Buffers/IBufferManager.cs
+++ b/src/LibHac/Fs/Buffers/IBufferManager.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+using CacheHandle = System.Int64;
+
+// ReSharper disable once CheckNamespace
+namespace LibHac.Fs
+{
+    // ReSharper disable once InconsistentNaming
+    public abstract class IBufferManager : IDisposable
+    {
+        public readonly struct BufferAttribute
+        {
+            public int Level { get; }
+
+            public BufferAttribute(int level)
+            {
+                Level = level;
+            }
+        }
+
+        public const int BufferLevelMin = 0;
+
+        public (UIntPtr address, nuint size) AllocateBuffer(nuint size, BufferAttribute attribute) =>
+            DoAllocateBuffer(size, attribute);
+
+        public void DeallocateBuffer(UIntPtr address, nuint size) => DoDeallocateBuffer(address, size);
+
+        public CacheHandle RegisterCache(UIntPtr address, nuint size, BufferAttribute attribute) =>
+            DoRegisterCache(address, size, attribute);
+
+        public (UIntPtr address, nuint size) AcquireCache(CacheHandle handle) => DoAcquireCache(handle);
+        public nuint GetTotalSize() => DoGetTotalSize();
+        public nuint GetFreeSize() => DoGetFreeSize();
+        public nuint GetTotalAllocatableSize() => DoGetTotalAllocatableSize();
+        public nuint GetFreeSizePeak() => DoGetFreeSizePeak();
+        public nuint GetTotalAllocatableSizePeak() => DoGetTotalAllocatableSizePeak();
+        public nuint GetRetriedCount() => DoGetRetriedCount();
+        public void ClearPeak() => DoClearPeak();
+
+        protected abstract (UIntPtr address, nuint size) DoAllocateBuffer(nuint size, BufferAttribute attribute);
+        protected abstract void DoDeallocateBuffer(UIntPtr address, nuint size);
+        protected abstract CacheHandle DoRegisterCache(UIntPtr address, nuint size, BufferAttribute attribute);
+        protected abstract (UIntPtr address, nuint size) DoAcquireCache(CacheHandle handle);
+        protected abstract nuint DoGetTotalSize();
+        protected abstract nuint DoGetFreeSize();
+        protected abstract nuint DoGetTotalAllocatableSize();
+        protected abstract nuint DoGetFreeSizePeak();
+        protected abstract nuint DoGetTotalAllocatableSizePeak();
+        protected abstract nuint DoGetRetriedCount();
+        protected abstract void DoClearPeak();
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/LibHac/Fs/Buffers/IBufferManager.cs
+++ b/src/LibHac/Fs/Buffers/IBufferManager.cs
@@ -6,6 +6,14 @@ using CacheHandle = System.Int64;
 namespace LibHac.Fs
 {
     // ReSharper disable once InconsistentNaming
+    /// <summary>
+    /// Handles buffer allocation, deallocation, and caching.<br/>
+    /// An allocated buffer may be placed in the cache using <see cref="RegisterCache"/>.
+    /// Caching a buffer saves the buffer for later retrieval, but tells the buffer manager that it can deallocate the
+    /// buffer if the memory is needed elsewhere. Any cached buffer may be evicted from the cache if there is no free
+    /// space for a requested allocation or if the cache is full when caching a new buffer.
+    /// A cached buffer can be retrieved using <see cref="AcquireCache"/>.
+    /// </summary>
     public abstract class IBufferManager : IDisposable
     {
         public readonly struct BufferAttribute
@@ -23,18 +31,80 @@ namespace LibHac.Fs
         public Buffer AllocateBuffer(int size, BufferAttribute attribute) =>
             DoAllocateBuffer(size, attribute);
 
+        /// <summary>
+        /// Allocates a new buffer with an attribute of level 0.
+        /// </summary>
+        /// <param name="size">The minimum size of the buffer to allocate</param>
+        /// <returns>The allocated <see cref="Buffer"/> if successful. Otherwise a null <see cref="Buffer"/>.</returns>
+        public Buffer AllocateBuffer(int size) => DoAllocateBuffer(size, new BufferAttribute());
+
+        /// <summary>
+        /// Deallocates the provided <see cref="Buffer"/>.
+        /// </summary>
+        /// <param name="buffer">The Buffer to deallocate.</param>
         public void DeallocateBuffer(Buffer buffer) => DoDeallocateBuffer(buffer);
 
+        /// <summary>
+        /// Adds a <see cref="Buffer"/> to the cache.
+        /// The buffer must have been allocated from this <see cref="IBufferManager"/>.<br/>
+        /// The buffer must not be used after adding it to the cache.
+        /// </summary>
+        /// <param name="buffer">The buffer to cache.</param>
+        /// <param name="attribute">The buffer attribute.</param>
+        /// <returns>A handle that can be used to retrieve the buffer at a later time.</returns>
         public CacheHandle RegisterCache(Buffer buffer, BufferAttribute attribute) =>
             DoRegisterCache(buffer, attribute);
 
+        /// <summary>
+        /// Attempts to acquire a cached <see cref="Buffer"/>.
+        /// If the buffer was evicted from the cache, a null buffer is returned.
+        /// </summary>
+        /// <param name="handle">The handle received when registering the buffer.</param>
+        /// <returns>The requested <see cref="Buffer"/> if it's still in the cache;
+        /// otherwise a null <see cref="Buffer"/></returns>
         public Buffer AcquireCache(CacheHandle handle) => DoAcquireCache(handle);
+
+        /// <summary>
+        /// Gets the total size of the <see cref="IBufferManager"/>'s heap.
+        /// </summary>
+        /// <returns>The total size of the heap.</returns>
         public int GetTotalSize() => DoGetTotalSize();
+
+        /// <summary>
+        /// Gets the amount of free space in the heap that is not currently allocated or cached.
+        /// </summary>
+        /// <returns>The amount of free space.</returns>
         public int GetFreeSize() => DoGetFreeSize();
+
+        /// <summary>
+        /// Gets the amount of space that can be used for new allocations.
+        /// This includes free space and space used by cached buffers.
+        /// </summary>
+        /// <returns>The amount of allocatable space.</returns>
         public int GetTotalAllocatableSize() => DoGetTotalAllocatableSize();
+
+        /// <summary>
+        /// Gets the largest amount of free space there's been at one time since the peak was last cleared.
+        /// </summary>
+        /// <returns>The peak amount of free space.</returns>
         public int GetFreeSizePeak() => DoGetFreeSizePeak();
+
+        /// <summary>
+        /// Gets the largest amount of allocatable space there's been at one time since the peak was last cleared.
+        /// </summary>
+        /// <returns>The peak amount of allocatable space.</returns>
         public int GetTotalAllocatableSizePeak() => DoGetTotalAllocatableSizePeak();
+
+        /// <summary>
+        /// Gets the number of times an allocation or cache registration needed to be retried after deallocating
+        /// a cache entry because of insufficient heap space or cache space.
+        /// </summary>
+        /// <returns>The number of retries.</returns>
         public int GetRetriedCount() => DoGetRetriedCount();
+
+        /// <summary>
+        /// Resets the free and allocatable peak sizes, setting the peak sizes to the actual current sizes.
+        /// </summary>
         public void ClearPeak() => DoClearPeak();
 
         protected abstract Buffer DoAllocateBuffer(int size, BufferAttribute attribute);

--- a/src/LibHac/Fs/Fsa/IFile.cs
+++ b/src/LibHac/Fs/Fsa/IFile.cs
@@ -188,7 +188,7 @@ namespace LibHac.Fs.Fsa
             if (!openMode.HasFlag(OpenMode.Write))
                 return ResultFs.InvalidOpenModeForWrite.Log();
 
-            Assert.AssertTrue(size >= 0);
+            Assert.True(size >= 0);
 
             return Result.Success;
         }

--- a/src/LibHac/Fs/ResultFs.cs
+++ b/src/LibHac/Fs/ResultFs.cs
@@ -136,6 +136,8 @@ namespace LibHac.Fs
             public static Result.Base AllocationFailureInEncryptedFileSystemCreatorA => new Result.Base(ModuleFs, 3394);
             /// <summary> In OpenFile or OpenDirectory<br/>Error code: 2002-3407; Inner value: 0x1a9e02</summary>
             public static Result.Base AllocationFailureInFileSystemInterfaceAdapter => new Result.Base(ModuleFs, 3407);
+            /// <summary> In Initialize allocating Cache array<br/>Error code: 2002-3411; Inner value: 0x1aa602</summary>
+            public static Result.Base AllocationFailureInBufferedStorageA => new Result.Base(ModuleFs, 3411);
             /// <summary>Error code: 2002-3420; Inner value: 0x1ab802</summary>
             public static Result.Base AllocationFailureInNew => new Result.Base(ModuleFs, 3420);
             /// <summary>Error code: 2002-3421; Inner value: 0x1aba02</summary>

--- a/src/LibHac/Fs/ResultFs.cs
+++ b/src/LibHac/Fs/ResultFs.cs
@@ -106,6 +106,10 @@ namespace LibHac.Fs
             public static Result.Base AllocationFailureFatFileSystemA => new Result.Base(ModuleFs, 3264);
             /// <summary>In Create allocating PartitionFileSystemCore<br/>Error code: 2002-3280; Inner value: 0x19a002</summary>
             public static Result.Base AllocationFailureInPartitionFileSystemCreatorA => new Result.Base(ModuleFs, 3280);
+            /// <summary>In Initialize allocating free areas array<br/>Error code: 2002-3294; Inner value: 0x19bc02</summary>
+            public static Result.Base AllocationFailureInFileSystemBuddyHeapA => new Result.Base(ModuleFs, 3294);
+            /// <summary>In CacheHandleTable::Initialize allocating an entry buffer<br/>Error code: 2002-3295; Inner value: 0x19be02</summary>
+            public static Result.Base AllocationFailureInFileSystemBufferManagerA => new Result.Base(ModuleFs, 3295);
             /// <summary>In Initialize allocating FileStorage<br/>Error code: 2002-3312; Inner value: 0x19e002</summary>
             public static Result.Base AllocationFailureInAesXtsFileA => new Result.Base(ModuleFs, 3312);
             /// <summary>In Initialize allocating AesXtsStorage<br/>Error code: 2002-3313; Inner value: 0x19e202</summary>

--- a/src/LibHac/Fs/SubStorage.cs
+++ b/src/LibHac/Fs/SubStorage.cs
@@ -81,9 +81,9 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.AssertTrue(IsValid());
-            Assert.AssertTrue(Offset >= 0);
-            Assert.AssertTrue(Size >= 0);
+            Assert.True(IsValid());
+            Assert.True(Offset >= 0);
+            Assert.True(Size >= 0);
         }
 
         /// <summary>
@@ -101,9 +101,9 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.AssertTrue(IsValid());
-            Assert.AssertTrue(Offset >= 0);
-            Assert.AssertTrue(Size >= 0);
+            Assert.True(IsValid());
+            Assert.True(Offset >= 0);
+            Assert.True(Size >= 0);
         }
 
         /// <summary>
@@ -125,10 +125,10 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.AssertTrue(IsValid());
-            Assert.AssertTrue(Offset >= 0);
-            Assert.AssertTrue(Size >= 0);
-            Assert.AssertTrue(other.Size >= offset + size);
+            Assert.True(IsValid());
+            Assert.True(Offset >= 0);
+            Assert.True(Size >= 0);
+            Assert.True(other.Size >= offset + size);
         }
 
         private bool IsValid() => BaseStorage != null;

--- a/src/LibHac/FsSrv/Impl/AccessControl.cs
+++ b/src/LibHac/FsSrv/Impl/AccessControl.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using LibHac.Common;
 using LibHac.Diag;
+using LibHac.Util;
 
 namespace LibHac.FsSrv.Impl
 {
@@ -127,7 +128,7 @@ namespace LibHac.FsSrv.Impl
                     accessControlData.Slice(data.SaveDataOwnerInfoOffset + sizeof(int), infoCount);
 
                 // The ID list must be 4-byte aligned
-                int idsOffset = Utilities.AlignUp(data.SaveDataOwnerInfoOffset + sizeof(int) + infoCount, 4);
+                int idsOffset = Alignment.AlignUp(data.SaveDataOwnerInfoOffset + sizeof(int) + infoCount, 4);
                 ReadOnlySpan<ulong> ids = MemoryMarshal.Cast<byte, ulong>(
                     accessControlData.Slice(idsOffset, infoCount * sizeof(ulong)));
 

--- a/src/LibHac/FsSrv/Impl/LocationResolverSet.cs
+++ b/src/LibHac/FsSrv/Impl/LocationResolverSet.cs
@@ -196,7 +196,7 @@ namespace LibHac.FsSrv.Impl
 
         private static int GetResolverIndexFromStorageId(StorageId id)
         {
-            Assert.AssertTrue(IsValidStorageId(id));
+            Assert.True(IsValidStorageId(id));
 
             return id switch
             {

--- a/src/LibHac/FsSrv/Impl/Utility.cs
+++ b/src/LibHac/FsSrv/Impl/Utility.cs
@@ -36,7 +36,7 @@ namespace LibHac.FsSrv.Impl
         private static Result EnsureDirectoryImpl(IFileSystem fileSystem, Span<byte> path)
         {
             // Double check the trailing separators have been trimmed
-            Assert.AssertTrue(path.Length <= 1 || path[path.Length - 1] != StringTraits.DirectorySeparator);
+            Assert.True(path.Length <= 1 || path[path.Length - 1] != StringTraits.DirectorySeparator);
 
             // Use the root path if the input path is empty
             var pathToCheck = new U8Span(path.IsEmpty ? FileSystemRootPath : path);
@@ -91,7 +91,7 @@ namespace LibHac.FsSrv.Impl
         private static Result EnsureParentDirectoryImpl(IFileSystem fileSystem, Span<byte> path)
         {
             // The path should not be empty or have a trailing directory separator
-            Assert.AssertTrue(path.Length > 0);
+            Assert.True(path.Length > 0);
             Assert.NotEqual(StringTraits.DirectorySeparator, path[path.Length - 1]);
 
             // Make sure the path's not too long

--- a/src/LibHac/FsSrv/NcaFileSystemService.cs
+++ b/src/LibHac/FsSrv/NcaFileSystemService.cs
@@ -121,7 +121,7 @@ namespace LibHac.FsSrv
                     if (originalResult.IsFailure())
                         return originalResult;
 
-                    Assert.AssertTrue(originalPathNormalizerHasValue);
+                    Assert.True(originalPathNormalizerHasValue);
 
                     // There is an original version and no patch version. Open the original directly
                     rc = ServiceImpl.OpenFileSystem(out tempFileSystem, originalPathNormalizer.Path, fsType, programId.Value);

--- a/src/LibHac/FsSrv/SaveDataIndexer.cs
+++ b/src/LibHac/FsSrv/SaveDataIndexer.cs
@@ -532,7 +532,7 @@ namespace LibHac.FsSrv
 
         private FlatMapKeyValueStore<SaveDataAttribute>.Iterator GetBeginIterator()
         {
-            Assert.AssertTrue(IsKvdbLoaded);
+            Assert.True(IsKvdbLoaded);
 
             return KvDatabase.GetBeginIterator();
         }

--- a/src/LibHac/FsSrv/SaveDataIndexerManager.cs
+++ b/src/LibHac/FsSrv/SaveDataIndexerManager.cs
@@ -168,7 +168,7 @@ namespace LibHac.FsSrv
 
             // ReSharper disable once RedundantAssignment
             Result rc = _tempIndexer.Indexer.Reset();
-            Assert.AssertTrue(rc.IsSuccess());
+            Assert.True(rc.IsSuccess());
         }
 
         public void InvalidateIndexer(SaveDataSpaceId spaceId)

--- a/src/LibHac/FsSystem/Aes128CtrTransform.cs
+++ b/src/LibHac/FsSystem/Aes128CtrTransform.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -36,7 +37,7 @@ namespace LibHac.FsSystem
 
         public int TransformBlock(Span<byte> data)
         {
-            int blockCount = Utilities.DivideByRoundUp(data.Length, BlockSizeBytes);
+            int blockCount = BitUtil.DivideUp(data.Length, BlockSizeBytes);
             int length = blockCount * BlockSizeBytes;
 
             byte[] counterXor = ArrayPool<byte>.Shared.Rent(length);

--- a/src/LibHac/FsSystem/Aes128XtsTransform.cs
+++ b/src/LibHac/FsSystem/Aes128XtsTransform.cs
@@ -28,6 +28,7 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -83,7 +84,7 @@ namespace LibHac.FsSystem
             /* get number of blocks */
             int m = count >> 4;
             int mo = count & 15;
-            int alignedCount = Utilities.AlignUp(count, BlockSizeBytes);
+            int alignedCount = Alignment.AlignUp(count, BlockSizeBytes);
 
             /* for i = 0 to m-2 do */
             if (mo == 0)

--- a/src/LibHac/FsSystem/AesXtsFile.cs
+++ b/src/LibHac/FsSystem/AesXtsFile.cs
@@ -2,6 +2,7 @@
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -37,7 +38,7 @@ namespace LibHac.FsSystem
                 ThrowHelper.ThrowResult(ResultFs.AesXtsFileHeaderInvalidKeys.Value, "NAX0 key derivation failed.");
             }
 
-            if (HeaderLength + Utilities.AlignUp(Header.Size, 0x10) > fileSize)
+            if (HeaderLength + Alignment.AlignUp(Header.Size, 0x10) > fileSize)
             {
                 ThrowHelper.ThrowResult(ResultFs.AesXtsFileTooShort.Value, "NAX0 key derivation failed.");
             }
@@ -118,7 +119,7 @@ namespace LibHac.FsSystem
             Result rc = BaseFile.Write(0, Header.ToBytes(false));
             if (rc.IsFailure()) return rc;
 
-            return BaseStorage.SetSize(Utilities.AlignUp(size, 0x10));
+            return BaseStorage.SetSize(Alignment.AlignUp(size, 0x10));
         }
 
         protected override void Dispose(bool disposing)

--- a/src/LibHac/FsSystem/AesXtsFileSystem.cs
+++ b/src/LibHac/FsSystem/AesXtsFileSystem.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -62,7 +63,7 @@ namespace LibHac.FsSystem
         /// <param name="key">The 256-bit key containing a 128-bit data key followed by a 128-bit tweak key.</param>
         public Result CreateFile(U8Span path, long size, CreateFileOptions options, byte[] key)
         {
-            long containerSize = AesXtsFile.HeaderLength + Utilities.AlignUp(size, 0x10);
+            long containerSize = AesXtsFile.HeaderLength + Alignment.AlignUp(size, 0x10);
 
             Result rc = BaseFileSystem.CreateFile(path, containerSize, options);
             if (rc.IsFailure()) return rc;

--- a/src/LibHac/FsSystem/BucketTree.cs
+++ b/src/LibHac/FsSystem/BucketTree.cs
@@ -35,11 +35,11 @@ namespace LibHac.FsSystem
         public Result Initialize(SubStorage nodeStorage, SubStorage entryStorage, int nodeSize, int entrySize,
             int entryCount)
         {
-            Assert.AssertTrue(entrySize >= sizeof(long));
-            Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.AssertTrue(!IsInitialized());
+            Assert.True(entrySize >= sizeof(long));
+            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
+            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
+            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.True(!IsInitialized());
 
             // Ensure valid entry count.
             if (entryCount <= 0)
@@ -119,7 +119,7 @@ namespace LibHac.FsSystem
 
         public Result Find(ref Visitor visitor, long virtualAddress)
         {
-            Assert.AssertTrue(IsInitialized());
+            Assert.True(IsInitialized());
 
             if (virtualAddress < 0)
                 return ResultFs.InvalidOffset.Log();
@@ -137,11 +137,11 @@ namespace LibHac.FsSystem
 
         public static long QueryNodeStorageSize(long nodeSize, long entrySize, int entryCount)
         {
-            Assert.AssertTrue(entrySize >= sizeof(long));
-            Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.AssertTrue(entryCount >= 0);
+            Assert.True(entrySize >= sizeof(long));
+            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
+            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
+            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.True(entryCount >= 0);
 
             if (entryCount <= 0)
                 return 0;
@@ -151,11 +151,11 @@ namespace LibHac.FsSystem
 
         public static long QueryEntryStorageSize(long nodeSize, long entrySize, int entryCount)
         {
-            Assert.AssertTrue(entrySize >= sizeof(long));
-            Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.AssertTrue(entryCount >= 0);
+            Assert.True(entrySize >= sizeof(long));
+            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
+            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
+            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.True(entryCount >= 0);
 
             if (entryCount <= 0)
                 return 0;
@@ -276,7 +276,7 @@ namespace LibHac.FsSystem
 
             public bool Allocate(int nodeSize)
             {
-                Assert.AssertTrue(_header == null);
+                Assert.True(_header == null);
 
                 _header = new long[nodeSize / sizeof(long)];
 
@@ -298,7 +298,7 @@ namespace LibHac.FsSystem
 
             public ref NodeHeader GetHeader()
             {
-                Assert.AssertTrue(_header.Length / sizeof(long) >= Unsafe.SizeOf<NodeHeader>());
+                Assert.True(_header.Length / sizeof(long) >= Unsafe.SizeOf<NodeHeader>());
 
                 return ref Unsafe.As<long, NodeHeader>(ref _header[0]);
             }
@@ -322,8 +322,8 @@ namespace LibHac.FsSystem
             {
                 _buffer = buffer;
 
-                Assert.AssertTrue(_buffer.Length >= Unsafe.SizeOf<NodeHeader>());
-                Assert.AssertTrue(_buffer.Length >= Unsafe.SizeOf<NodeHeader>() + GetHeader().Count * Unsafe.SizeOf<TEntry>());
+                Assert.True(_buffer.Length >= Unsafe.SizeOf<NodeHeader>());
+                Assert.True(_buffer.Length >= Unsafe.SizeOf<NodeHeader>() + GetHeader().Count * Unsafe.SizeOf<TEntry>());
             }
 
             public int GetCount() => GetHeader().Count;
@@ -381,8 +381,8 @@ namespace LibHac.FsSystem
 
             public Result Initialize(BucketTree tree)
             {
-                Assert.AssertTrue(tree != null);
-                Assert.AssertTrue(Tree == null || tree == Tree);
+                Assert.True(tree != null);
+                Assert.True(Tree == null || tree == Tree);
 
                 if (Entry == null)
                 {

--- a/src/LibHac/FsSystem/BucketTree.cs
+++ b/src/LibHac/FsSystem/BucketTree.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using LibHac.Common;
 using LibHac.Diag;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -37,7 +38,7 @@ namespace LibHac.FsSystem
             Assert.AssertTrue(entrySize >= sizeof(long));
             Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
             Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(Utilities.IsPowerOfTwo(nodeSize));
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
             Assert.AssertTrue(!IsInitialized());
 
             // Ensure valid entry count.
@@ -139,7 +140,7 @@ namespace LibHac.FsSystem
             Assert.AssertTrue(entrySize >= sizeof(long));
             Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
             Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(Utilities.IsPowerOfTwo(nodeSize));
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
             Assert.AssertTrue(entryCount >= 0);
 
             if (entryCount <= 0)
@@ -153,7 +154,7 @@ namespace LibHac.FsSystem
             Assert.AssertTrue(entrySize >= sizeof(long));
             Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
             Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.AssertTrue(Utilities.IsPowerOfTwo(nodeSize));
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
             Assert.AssertTrue(entryCount >= 0);
 
             if (entryCount <= 0)
@@ -175,7 +176,7 @@ namespace LibHac.FsSystem
         private static int GetEntrySetCount(long nodeSize, long entrySize, int entryCount)
         {
             int entryCountPerNode = GetEntryCount(nodeSize, entrySize);
-            return Utilities.DivideByRoundUp(entryCount, entryCountPerNode);
+            return BitUtil.DivideUp(entryCount, entryCountPerNode);
         }
 
         public static int GetNodeL2Count(long nodeSize, long entrySize, int entryCount)
@@ -186,10 +187,10 @@ namespace LibHac.FsSystem
             if (entrySetCount <= offsetCountPerNode)
                 return 0;
 
-            int nodeL2Count = Utilities.DivideByRoundUp(entrySetCount, offsetCountPerNode);
+            int nodeL2Count = BitUtil.DivideUp(entrySetCount, offsetCountPerNode);
             Abort.DoAbortUnless(nodeL2Count <= offsetCountPerNode);
 
-            return Utilities.DivideByRoundUp(entrySetCount - (offsetCountPerNode - (nodeL2Count - 1)), offsetCountPerNode);
+            return BitUtil.DivideUp(entrySetCount - (offsetCountPerNode - (nodeL2Count - 1)), offsetCountPerNode);
         }
 
         private static long GetBucketTreeEntryOffset(long entrySetOffset, long entrySize, int entryIndex)

--- a/src/LibHac/FsSystem/BucketTreeBuilder.cs
+++ b/src/LibHac/FsSystem/BucketTreeBuilder.cs
@@ -42,10 +42,10 @@ namespace LibHac.FsSystem
             public Result Initialize(SubStorage headerStorage, SubStorage nodeStorage, SubStorage entryStorage,
                 int nodeSize, int entrySize, int entryCount)
             {
-                Assert.AssertTrue(entrySize >= sizeof(long));
-                Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-                Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-                Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
+                Assert.True(entrySize >= sizeof(long));
+                Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
+                Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
+                Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
 
                 if (headerStorage is null || nodeStorage is null || entryStorage is null)
                     return ResultFs.NullptrArgument.Log();
@@ -99,7 +99,7 @@ namespace LibHac.FsSystem
             /// <returns>The <see cref="Result"/> of the operation.</returns>
             public Result Add<T>(ref T entry) where T : unmanaged
             {
-                Assert.AssertTrue(Unsafe.SizeOf<T>() == EntrySize);
+                Assert.True(Unsafe.SizeOf<T>() == EntrySize);
 
                 if (CurrentEntryIndex >= EntryCount)
                     return ResultFs.OutOfRange.Log();

--- a/src/LibHac/FsSystem/BucketTreeBuilder.cs
+++ b/src/LibHac/FsSystem/BucketTreeBuilder.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using LibHac.Common;
 using LibHac.Diag;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -44,7 +45,7 @@ namespace LibHac.FsSystem
                 Assert.AssertTrue(entrySize >= sizeof(long));
                 Assert.AssertTrue(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
                 Assert.AssertTrue(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-                Assert.AssertTrue(Utilities.IsPowerOfTwo(nodeSize));
+                Assert.AssertTrue(BitUtil.IsPowerOfTwo(nodeSize));
 
                 if (headerStorage is null || nodeStorage is null || entryStorage is null)
                     return ResultFs.NullptrArgument.Log();
@@ -267,7 +268,7 @@ namespace LibHac.FsSystem
                     if (rc.IsFailure()) return rc;
                 }
 
-                int l2NodeIndex = Utilities.DivideByRoundUp(CurrentL2OffsetIndex, OffsetsPerNode) - 2;
+                int l2NodeIndex = BitUtil.DivideUp(CurrentL2OffsetIndex, OffsetsPerNode) - 2;
                 int indexInL2Node = CurrentL2OffsetIndex % OffsetsPerNode;
 
                 // Finalize the current L2 node if needed
@@ -291,7 +292,7 @@ namespace LibHac.FsSystem
                 // L1 count depends on the existence or absence of L2 nodes
                 if (CurrentL2OffsetIndex == 0)
                 {
-                    l1NodeHeader.Count = Utilities.DivideByRoundUp(CurrentEntryIndex, EntriesPerEntrySet);
+                    l1NodeHeader.Count = BitUtil.DivideUp(CurrentEntryIndex, EntriesPerEntrySet);
                 }
                 else
                 {

--- a/src/LibHac/FsSystem/Buffers/BufferManagerUtility.cs
+++ b/src/LibHac/FsSystem/Buffers/BufferManagerUtility.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using LibHac.Diag;
+using LibHac.Fs;
+using Buffer = LibHac.Fs.Buffer;
+
+namespace LibHac.FsSystem.Buffers
+{
+    public struct BufferManagerContext
+    {
+        private bool _needsBlocking;
+
+        public bool IsNeedBlocking() => _needsBlocking;
+        public void SetNeedBlocking(bool needsBlocking) => _needsBlocking = needsBlocking;
+    }
+
+    public struct ScopedBufferManagerContextRegistration : IDisposable
+    {
+        private BufferManagerContext _oldContext;
+
+        // ReSharper disable once UnusedParameter.Local
+        public ScopedBufferManagerContextRegistration(int unused = default)
+        {
+            _oldContext = BufferManagerUtility.GetBufferManagerContext();
+        }
+
+        public void Dispose()
+        {
+            BufferManagerUtility.RegisterBufferManagerContext(in _oldContext);
+        }
+    }
+
+    internal static class BufferManagerUtility
+    {
+        // Todo: Use TimeSpan
+        private const int RetryWait = 10;
+
+        [ThreadStatic]
+        private static BufferManagerContext _context;
+
+        public delegate bool IsValidBufferFunction(in Buffer buffer);
+
+        public static Result DoContinuouslyUntilBufferIsAllocated(Func<Result> function, Func<Result> onFailure,
+            [CallerMemberName] string callerName = "")
+        {
+            const int bufferAllocationRetryLogCountMax = 10;
+            const int bufferAllocationRetryLogInterval = 100;
+
+            Result result;
+
+            for (int count = 1; ; count++)
+            {
+                result = function();
+                if (!ResultFs.BufferAllocationFailed.Includes(result))
+                    break;
+
+                // Failed to allocate. Wait and try again.
+                if (1 <= count && count <= bufferAllocationRetryLogCountMax ||
+                    count % bufferAllocationRetryLogInterval == 0)
+                {
+                    // Todo: Log allocation failure
+                }
+
+                Result rc = onFailure();
+                if (rc.IsFailure()) return rc;
+
+                Thread.Sleep(RetryWait);
+            }
+
+            return result;
+        }
+
+        public static Result DoContinuouslyUntilBufferIsAllocated(Func<Result> function,
+            [CallerMemberName] string callerName = "")
+        {
+            return DoContinuouslyUntilBufferIsAllocated(function, static () => Result.Success, callerName);
+        }
+
+        public static void RegisterBufferManagerContext(in BufferManagerContext context)
+        {
+            _context = context;
+        }
+
+        public static ref BufferManagerContext GetBufferManagerContext() => ref _context;
+
+        public static void EnableBlockingBufferManagerAllocation()
+        {
+            ref BufferManagerContext context = ref GetBufferManagerContext();
+            context.SetNeedBlocking(true);
+        }
+
+        public static Result AllocateBufferUsingBufferManagerContext(out Buffer outBuffer, IBufferManager bufferManager,
+            int size, IBufferManager.BufferAttribute attribute, IsValidBufferFunction isValidBuffer,
+            [CallerMemberName] string callerName = "")
+        {
+            Assert.NotNull(bufferManager);
+            Assert.NotNull(callerName);
+
+            // Clear the output.
+            outBuffer = default;
+            Buffer tempBuffer = default;
+
+            // Get the context.
+            ref BufferManagerContext context = ref GetBufferManagerContext();
+
+            Result AllocateBufferImpl()
+            {
+                Buffer buffer = bufferManager.AllocateBuffer(size, attribute);
+
+                if (!isValidBuffer(in buffer))
+                {
+                    if (!buffer.IsNull)
+                    {
+                        bufferManager.DeallocateBuffer(buffer);
+                    }
+
+                    return ResultFs.BufferAllocationFailed.Log();
+                }
+
+                tempBuffer = buffer;
+                return Result.Success;
+            }
+
+            if (!context.IsNeedBlocking())
+            {
+                // If we don't need to block, just allocate the buffer.
+                Result rc = AllocateBufferImpl();
+                if (rc.IsFailure()) return rc;
+            }
+            else
+            {
+                // Otherwise, try to allocate repeatedly.
+                Result rc = DoContinuouslyUntilBufferIsAllocated(AllocateBufferImpl);
+                if (rc.IsFailure()) return rc;
+            }
+
+            Assert.True(!tempBuffer.IsNull);
+            outBuffer = tempBuffer;
+            return Result.Success;
+        }
+    }
+}

--- a/src/LibHac/FsSystem/Buffers/FileSystemBuddyHeap.cs
+++ b/src/LibHac/FsSystem/Buffers/FileSystemBuddyHeap.cs
@@ -1,0 +1,595 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using LibHac.Diag;
+using LibHac.Fs;
+using LibHac.Util;
+
+// ReSharper disable once CheckNamespace
+namespace LibHac.FsSystem
+{
+    public unsafe class FileSystemBuddyHeap : IDisposable
+    {
+        private static readonly nuint BufferAlignment = (nuint)Unsafe.SizeOf<nuint>();
+        private static readonly nuint BlockSizeMin = (nuint)(2 * Unsafe.SizeOf<nuint>());
+        private const int OrderUpperLimit = 8 * sizeof(int) - 1;
+
+        private nuint BlockSize { get; set; }
+        private int OrderMax { get; set; }
+        private UIntPtr HeapStart { get; set; }
+        private nuint HeapSize { get; set; }
+
+        private PageList* FreeLists { get; set; }
+        private nuint TotalFreeSize { get; set; }
+        private PageList* ExternalFreeLists { get; set; }
+        private PageList[] InternalFreeLists { get; set; }
+
+        // Addition: Handle to allow initialization with a Memory<byte>
+        private MemoryHandle PinnedMemoryHandle { get; set; }
+
+        private struct PageList
+        {
+            private PageEntry* FirstPageEntry { get; set; }
+            private PageEntry* LastPageEntry { get; set; }
+            private int EntryCount { get; set; }
+
+            public bool IsEmpty() => EntryCount == 0;
+            public int GetSize() => EntryCount;
+
+            public PageEntry* GetFront() => FirstPageEntry;
+
+            public PageEntry* PopFront()
+            {
+                Assert.True(EntryCount > 0);
+
+                // Get the first entry.
+                PageEntry* pageEntry = FirstPageEntry;
+
+                // Advance our list.
+                FirstPageEntry = pageEntry->Next;
+                pageEntry->Next = null;
+
+                // Decrement our count.
+                EntryCount--;
+                Assert.True(EntryCount >= 0);
+
+                // If this was our last page, clear our last entry.
+                if (EntryCount == 0)
+                {
+                    LastPageEntry = null;
+                }
+
+                return pageEntry;
+            }
+
+            public void PushBack(PageEntry* pageEntry)
+            {
+                Assert.True(pageEntry != null);
+
+                // If we're empty, we want to set the first page entry.
+                if (IsEmpty())
+                {
+                    FirstPageEntry = pageEntry;
+                }
+                else
+                {
+                    // We're not empty, so push the page to the back.
+                    Assert.True(LastPageEntry != pageEntry);
+                    LastPageEntry->Next = pageEntry;
+                }
+
+                // Set our last page entry to be this one, and link it to the list.
+                LastPageEntry = pageEntry;
+                LastPageEntry->Next = null;
+
+                // Increment our entry count.
+                EntryCount++;
+                Assert.True(EntryCount > 0);
+            }
+
+            public bool Remove(PageEntry* pageEntry)
+            {
+                Assert.True(pageEntry != null);
+
+                // If we're empty, we can't remove the page list.
+                if (IsEmpty())
+                {
+                    return false;
+                }
+
+                // We're going to loop over all pages to find this one, then unlink it.
+                PageEntry* prevEntry = null;
+                PageEntry* curEntry = FirstPageEntry;
+
+                while (true)
+                {
+                    // Check if we found the page.
+                    if (curEntry == pageEntry)
+                    {
+                        if (curEntry == FirstPageEntry)
+                        {
+                            // If it's the first page, we just set our first.
+                            FirstPageEntry = curEntry->Next;
+                        }
+                        else if (curEntry == LastPageEntry)
+                        {
+                            // If it's the last page, we set our last.
+                            LastPageEntry = prevEntry;
+                            LastPageEntry->Next = null;
+                        }
+                        else
+                        {
+                            // If it's in the middle, we just unlink.
+                            prevEntry->Next = curEntry->Next;
+                        }
+
+                        // Unlink this entry's next.
+                        curEntry->Next = null;
+
+                        // Update our entry count.
+                        EntryCount--;
+                        Assert.True(EntryCount >= 0);
+
+                        return true;
+                    }
+
+                    // If we have no next page, we can't remove.
+                    if (curEntry->Next == null)
+                    {
+                        return false;
+                    }
+
+                    // Advance to the next item in the list.
+                    prevEntry = curEntry;
+                    curEntry = curEntry->Next;
+                }
+            }
+        }
+
+        private struct PageEntry
+        {
+            public PageEntry* Next;
+        }
+
+        public void Dispose()
+        {
+            FreeLists = null;
+            ExternalFreeLists = null;
+            InternalFreeLists = null;
+            PinnedMemoryHandle.Dispose();
+        }
+
+        public static int GetBlockCountFromOrder(int order)
+        {
+            Assert.True(0 <= order);
+            Assert.True(order < OrderUpperLimit);
+            return 1 << order;
+        }
+
+        public static nuint QueryWorkBufferSize(int orderMax)
+        {
+            Assert.InRange(orderMax, 1, OrderUpperLimit);
+
+            var pageListSize = (nint)Unsafe.SizeOf<PageList>();
+            uint pageListAlignment = (uint)Unsafe.SizeOf<nint>();
+            const uint ulongAlignment = 8;
+
+            return (nuint)Alignment.AlignUpPow2(pageListSize * (orderMax + 1) + pageListAlignment, ulongAlignment);
+        }
+
+        public static int QueryOrderMax(nuint size, nuint blockSize)
+        {
+            Assert.True(size >= blockSize);
+            Assert.True(blockSize >= BlockSizeMin);
+            Assert.True(BitUtil.IsPowerOfTwo(blockSize));
+
+            int blockCount = (int)(Alignment.AlignUpPow2(size, (uint)blockSize) / blockSize);
+            for (int order = 1; ; order++)
+            {
+                if (blockCount <= GetBlockCountFromOrder(order))
+                    return order;
+            }
+        }
+
+        public Result Initialize(Memory<byte> heapBuffer, uint blockSize, int orderMax)
+        {
+            PinnedMemoryHandle = heapBuffer.Pin();
+
+            var address = (UIntPtr)PinnedMemoryHandle.Pointer;
+            var size = (nuint)heapBuffer.Length;
+
+            return Initialize(address, size, blockSize, orderMax);
+        }
+
+        public Result Initialize(UIntPtr address, nuint size, nuint blockSize, void* workBuffer, nuint workBufferSize)
+        {
+            return Initialize(address, size, blockSize, QueryOrderMax(size, blockSize), workBuffer, workBufferSize);
+        }
+
+        public Result Initialize(UIntPtr address, nuint size, nuint blockSize, int orderMax, void* workBuffer,
+            nuint workBufferSize)
+        {
+            // Note: Buffer size assert is done before adjusting for alignment
+            Assert.True(workBufferSize >= QueryWorkBufferSize(orderMax));
+
+            uint pageListAlignment = (uint)Unsafe.SizeOf<nint>();
+            var alignedWork = (void*)Alignment.AlignUpPow2((ulong)workBuffer, pageListAlignment);
+            ExternalFreeLists = (PageList*)alignedWork;
+
+            return Initialize(address, size, blockSize, orderMax);
+        }
+
+        public Result Initialize(UIntPtr address, nuint size, nuint blockSize)
+        {
+            return Initialize(address, size, blockSize, QueryOrderMax(size, blockSize));
+        }
+
+        public Result Initialize(UIntPtr address, nuint size, nuint blockSize, int orderMax)
+        {
+            Assert.True(FreeLists == null);
+            Assert.True(address != UIntPtr.Zero);
+            Assert.True(Alignment.IsAlignedPow2(address.ToUInt64(), (uint)BufferAlignment));
+            Assert.True(blockSize >= BlockSizeMin);
+            Assert.True(BitUtil.IsPowerOfTwo(blockSize));
+            Assert.True(size >= blockSize);
+            Assert.True(orderMax > 0);
+            Assert.True(orderMax < OrderUpperLimit);
+
+            // Set up our basic member variables
+            BlockSize = blockSize;
+            OrderMax = orderMax;
+            HeapStart = address;
+            HeapSize = size;
+
+            TotalFreeSize = 0;
+
+            // Determine page sizes
+            nuint maxPageSize = BlockSize << OrderMax;
+            nuint maxPageCount = (nuint)Alignment.AlignUp(HeapSize, (uint)maxPageSize) / maxPageSize;
+            Assert.True(maxPageCount > 0);
+
+            // Setup the free lists
+            if (ExternalFreeLists is not null)
+            {
+                Assert.Null(InternalFreeLists);
+                FreeLists = ExternalFreeLists;
+            }
+            else
+            {
+                InternalFreeLists = new PageList[OrderMax + 1];
+                FreeLists = (PageList*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(InternalFreeLists));
+                if (InternalFreeLists == null)
+                    return ResultFs.AllocationFailureInFileSystemBuddyHeapA.Log();
+            }
+
+            // All but the last page region should go to the max order.
+            for (nuint i = 0; i < maxPageCount - 1; i++)
+            {
+                PageEntry* pageEntry = GetPageEntryFromAddress(HeapStart + i * maxPageSize);
+                FreeLists[orderMax].PushBack(pageEntry);
+            }
+
+            TotalFreeSize += (nuint)FreeLists[orderMax].GetSize() * GetBytesFromOrder(orderMax);
+
+            // Allocate remaining space to smaller orders as possible.
+            {
+                nuint remaining = HeapSize - (maxPageCount - 1) * maxPageSize;
+                nuint curAddress = (nuint)HeapStart - (maxPageCount - 1) * maxPageSize;
+                Assert.True(Alignment.IsAlignedPow2(remaining, (uint)BlockSize));
+
+                do
+                {
+                    // Determine what order we can use.
+                    int order = GetOrderFromBytes(remaining + 1);
+                    if (order < 0)
+                    {
+                        Assert.True(GetOrderFromBytes(remaining) == orderMax);
+                        order = OrderMax + 1;
+                    }
+
+                    Assert.True(0 < order);
+                    Assert.True(order <= OrderMax + 1);
+
+                    // Add to the correct free list.
+                    FreeLists[order - 1].PushBack(GetPageEntryFromAddress(curAddress));
+                    TotalFreeSize += GetBytesFromOrder(order - 1);
+
+                    // Move on to the next order.
+                    nuint pageSize = GetBytesFromOrder(order - 1);
+                    curAddress += pageSize;
+                    remaining -= pageSize;
+                } while (BlockSize <= remaining);
+            }
+
+            return Result.Success;
+        }
+
+        public void* AllocateByOrder(int order)
+        {
+            Assert.True(FreeLists != null);
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            // Get the page entry.
+            PageEntry* pageEntry = GetFreePageEntry(order);
+
+            if (pageEntry != null)
+            {
+                // Ensure we're allocating an unlinked page.
+                Assert.True(pageEntry->Next == null);
+
+                // Return the address for this entry.
+                return (void*)GetAddressFromPageEntry(pageEntry);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public void Free(void* pointer, int order)
+        {
+            Assert.True(FreeLists != null);
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            // Allow Free(null)
+            if (pointer == null)
+                return;
+
+            // Ensure the pointer is block aligned.
+            Assert.True(Alignment.IsAlignedPow2((nuint)pointer - HeapStart, (uint)GetBlockSize()));
+
+            // Get the page entry.
+            PageEntry* pageEntry = GetPageEntryFromAddress((UIntPtr)pointer);
+            Assert.True(IsAlignedToOrder(pageEntry, order));
+
+            /* Reinsert into the free lists. */
+            JoinBuddies(pageEntry, order);
+        }
+
+        public nuint GetTotalFreeSize()
+        {
+            Assert.True(FreeLists != null);
+            return TotalFreeSize;
+        }
+
+        public nuint GetAllocatableSizeMax()
+        {
+            Assert.True(FreeLists != null);
+
+            // The maximum allocatable size is a chunk from the biggest non-empty order.
+            for (int order = GetOrderMax(); order >= 0; order--)
+            {
+                if (FreeLists[order].IsEmpty())
+                {
+                    return GetBytesFromOrder(order);
+                }
+            }
+
+            // If all orders are empty, then we can't allocate anything.
+            return 0;
+        }
+
+        public void Dump()
+        {
+            Assert.True(FreeLists != null);
+            throw new NotImplementedException();
+        }
+
+        public int GetOrderFromBytes(nuint size)
+        {
+            Assert.True(FreeLists != null);
+            return GetOrderFromBlockCount(GetBlockCountFromSize(size));
+        }
+
+        public nuint GetBytesFromOrder(int order)
+        {
+            Assert.True(FreeLists != null);
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            return GetBlockSize() << order;
+        }
+
+        public int GetOrderMax()
+        {
+            Assert.True(FreeLists != null);
+            return OrderMax;
+        }
+
+        public nuint GetBlockSize()
+        {
+            Assert.True(FreeLists != null);
+            return BlockSize;
+        }
+
+        // Not in original
+        public int GetPageBlockCountMax()
+        {
+            Assert.True(FreeLists != null);
+            return 1 << GetOrderMax();
+        }
+
+        // Not in original
+        public nuint GetPageSizeMax()
+        {
+            Assert.True(FreeLists != null);
+            return (nuint)GetPageBlockCountMax() * GetBlockSize();
+        }
+
+        private void DivideBuddies(PageEntry* pageEntry, int requiredOrder, int chosenOrder)
+        {
+            Assert.True(FreeLists != null);
+            Assert.True(requiredOrder >= 0);
+            Assert.True(chosenOrder >= requiredOrder);
+            Assert.True(chosenOrder <= GetOrderMax());
+
+            // Start at the end of the entry.
+            nuint address = GetAddressFromPageEntry(pageEntry) + GetBytesFromOrder(chosenOrder);
+
+            for (int order = chosenOrder; order > requiredOrder; order--)
+            {
+                // For each order, subtract that order's size from the address to get the start of a new block.
+                address -= GetBytesFromOrder(order - 1);
+                PageEntry* dividedEntry = GetPageEntryFromAddress(address);
+
+                // Push back to the list.
+                FreeLists[order - 1].PushBack(dividedEntry);
+                TotalFreeSize += GetBytesFromOrder(order - 1);
+            }
+        }
+
+        private void JoinBuddies(PageEntry* pageEntry, int order)
+        {
+            Assert.True(pageEntry != null);
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            PageEntry* curEntry = pageEntry;
+            int curOrder = order;
+
+            while (curOrder < GetOrderMax())
+            {
+                // Get the buddy page.
+                PageEntry* buddyEntry = GetBuddy(curEntry, curOrder);
+
+                // Check whether the buddy is in the relevant free list.
+                if (buddyEntry != null && FreeLists[curOrder].Remove(buddyEntry))
+                {
+                    TotalFreeSize -= GetBytesFromOrder(curOrder);
+
+                    // Ensure we coalesce with the correct buddy when page is aligned
+                    if (!IsAlignedToOrder(curEntry, curOrder + 1))
+                    {
+                        curEntry = buddyEntry;
+                    }
+
+                    curOrder++;
+                }
+                else
+                {
+                    // Buddy isn't in the free list, so we can't coalesce.
+                    break;
+                }
+            }
+
+            // Insert the coalesced entry into the free list.
+            FreeLists[curOrder].PushBack(curEntry);
+            TotalFreeSize += GetBytesFromOrder(curOrder);
+        }
+
+        private PageEntry* GetBuddy(PageEntry* pageEntry, int order)
+        {
+            Assert.True(pageEntry != null);
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            nuint address = GetAddressFromPageEntry(pageEntry);
+            nuint offset = (nuint)GetBlockCountFromOrder(order) * GetBlockSize();
+
+            if (IsAlignedToOrder(pageEntry, order + 1))
+            {
+                // If the page entry is aligned to the next order,
+                // return the buddy block to the right of the current entry.
+                return address + offset < HeapStart + HeapSize ? GetPageEntryFromAddress(address + offset) : null;
+            }
+            else
+            {
+                // If the page entry isn't aligned, return the buddy block to the left of the current entry.
+                return HeapStart <= address - offset ? GetPageEntryFromAddress(address - offset) : null;
+            }
+        }
+
+        private PageEntry* GetFreePageEntry(int order)
+        {
+            Assert.True(order >= 0);
+            Assert.True(order <= GetOrderMax());
+
+            // Try orders from low to high until we find a free page entry.
+            for (int curOrder = order; curOrder <= GetOrderMax(); curOrder++)
+            {
+                ref PageList freeList = ref FreeLists[curOrder];
+                if (!freeList.IsEmpty())
+                {
+                    // The current list isn't empty, so grab an entry from it.
+                    PageEntry* pageEntry = freeList.PopFront();
+                    Assert.True(pageEntry != null);
+
+                    // Update size bookkeeping.
+                    TotalFreeSize -= GetBytesFromOrder(curOrder);
+
+                    // If we allocated more memory than needed, free the unneeded portion.
+                    DivideBuddies(pageEntry, order, curOrder);
+                    Assert.True(pageEntry->Next == null);
+
+                    // Return the newly-divided entry.
+                    return pageEntry;
+                }
+            }
+
+            // We failed to find a free page.
+            return null;
+        }
+
+        private int GetOrderFromBlockCount(int blockCount)
+        {
+            Assert.True(blockCount >= 0);
+
+            // Return the first order with a big enough block count.
+            for (int order = 0; order <= GetOrderMax(); ++order)
+            {
+                if (blockCount <= GetBlockCountFromOrder(order))
+                {
+                    return order;
+                }
+            }
+
+            return -1;
+        }
+
+        private int GetBlockCountFromSize(nuint size)
+        {
+            nuint blockSize = GetBlockSize();
+            return (int)(Alignment.AlignUpPow2(size, (uint)blockSize) / blockSize);
+        }
+
+        private UIntPtr GetAddressFromPageEntry(PageEntry* pageEntry)
+        {
+            var address = new UIntPtr(pageEntry);
+
+            Assert.True((nuint)HeapStart <= address);
+            Assert.True(address < HeapStart + HeapSize);
+            Assert.True(Alignment.IsAlignedPow2((nuint)address - HeapStart, (uint)GetBlockSize()));
+
+            return address;
+        }
+
+        private PageEntry* GetPageEntryFromAddress(UIntPtr address)
+        {
+            Assert.True((nuint)HeapStart <= address);
+            Assert.True(address < HeapStart + HeapSize);
+
+            ulong blockStart = (ulong)HeapStart +
+                               Alignment.AlignDownPow2((nuint)address - HeapStart, (uint)GetBlockSize());
+            return (PageEntry*)blockStart;
+        }
+
+        private int GetIndexFromPageEntry(PageEntry* pageEntry)
+        {
+            var address = (nuint)pageEntry;
+
+            Assert.True(HeapStart <= address);
+            Assert.True(address < HeapStart + HeapSize);
+            Assert.True(Alignment.IsAlignedPow2(address - HeapStart, (uint)GetBlockSize()));
+
+            return (int)((address - HeapStart) / GetBlockSize());
+        }
+
+        private bool IsAlignedToOrder(PageEntry* pageEntry, int order)
+        {
+            return Alignment.IsAlignedPow2(GetIndexFromPageEntry(pageEntry), (uint)GetBlockCountFromOrder(order));
+        }
+    }
+}

--- a/src/LibHac/FsSystem/Buffers/FileSystemBufferManager.cs
+++ b/src/LibHac/FsSystem/Buffers/FileSystemBufferManager.cs
@@ -1,0 +1,562 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using LibHac.Diag;
+using LibHac.Fs;
+using LibHac.Util;
+using Buffer = LibHac.Fs.Buffer;
+using CacheHandle = System.Int64;
+
+// ReSharper disable once CheckNamespace
+namespace LibHac.FsSystem
+{
+    public class FileSystemBufferManager : IBufferManager
+    {
+        private class CacheHandleTable
+        {
+            private struct Entry
+            {
+                private CacheHandle _handle;
+                private Buffer _buffer;
+                private BufferAttribute _attribute;
+
+                public void Initialize(CacheHandle handle, Buffer buffer, BufferAttribute attribute)
+                {
+                    _handle = handle;
+                    _buffer = buffer;
+                    _attribute = attribute;
+                }
+
+                public readonly CacheHandle GetHandle() => _handle;
+                public readonly Buffer GetBuffer() => _buffer;
+                public readonly int GetSize() => _buffer.Length;
+                public readonly BufferAttribute GetBufferAttribute() => _attribute;
+            }
+
+            private struct AttrInfo
+            {
+                private int _level;
+                private int _cacheCount;
+                private int _cacheSize;
+
+                public AttrInfo(int level, int cacheCount, int cacheSize)
+                {
+                    _level = level;
+                    _cacheCount = cacheCount;
+                    _cacheSize = cacheSize;
+                }
+
+                public int GetLevel() => _level;
+                public int GetCacheCount() => _cacheCount;
+                public void IncrementCacheCount() => _cacheCount++;
+                public void DecrementCacheCount() => _cacheCount--;
+                public int GetCacheSize() => _cacheSize;
+                public void AddCacheSize(int diff) => _cacheSize += diff;
+                public void SubtractCacheSize(int diff)
+                {
+                    Assert.True(_cacheSize >= diff);
+                    _cacheSize -= diff;
+                }
+            }
+
+            private Entry[] Entries { get; set; }
+            private int EntryCount { get; set; }
+            private int EntryCountMax { get; set; }
+            private LinkedList<AttrInfo> AttrList { get; set; } = new();
+            private int CacheCountMin { get; set; }
+            private int CacheSizeMin { get; set; }
+            private int TotalCacheSize { get; set; }
+            private CacheHandle CurrentHandle { get; set; }
+
+            // ReSharper disable once UnusedMember.Local
+            // We can't use an external buffer in C# without ensuring all allocated buffers are pinned.
+            // This function is left here anyway for completion's sake.
+            public static int QueryWorkBufferSize(int maxCacheCount)
+            {
+                Assert.True(maxCacheCount > 0);
+
+                int entryAlignment = sizeof(CacheHandle);
+                int attrInfoAlignment = Unsafe.SizeOf<nuint>();
+
+                int entrySize = Unsafe.SizeOf<Entry>() * maxCacheCount;
+                int attrListSize = Unsafe.SizeOf<AttrInfo>() * 0x100;
+                return (int)Alignment.AlignUpPow2(
+                    (ulong)(entrySize + attrListSize + entryAlignment + attrInfoAlignment), 8);
+            }
+
+            public Result Initialize(int maxCacheCount)
+            {
+                // Validate pre-conditions.
+                Assert.True(Entries == null);
+
+                // Note: We don't have the option of using an external Entry buffer like the original
+                // because Entry includes managed references so we can't cast a byte* to Entry* without pinning.
+                // If we don't have an external buffer, try to allocate an internal one.
+
+                Entries = new Entry[maxCacheCount];
+
+                if (Entries == null)
+                {
+                    return ResultFs.AllocationFailureInFileSystemBufferManagerA.Log();
+                }
+
+                // Set entries.
+                EntryCount = 0;
+                EntryCountMax = maxCacheCount;
+
+                Assert.True(Entries != null);
+
+                CacheCountMin = maxCacheCount / 16;
+                CacheSizeMin = CacheCountMin * 0x100;
+
+                return Result.Success;
+            }
+
+            // ReSharper disable once UnusedParameter.Local
+            private int GetCacheCountMin(BufferAttribute attr)
+            {
+                return CacheCountMin;
+            }
+
+            // ReSharper disable once UnusedParameter.Local
+            private int GetCacheSizeMin(BufferAttribute attr)
+            {
+                return CacheSizeMin;
+            }
+
+            public bool Register(out CacheHandle handle, Buffer buffer, BufferAttribute attr)
+            {
+                Unsafe.SkipInit(out handle);
+
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+                Assert.True(!Unsafe.IsNullRef(ref handle));
+
+                // Get the entry.
+                ref Entry entry = ref AcquireEntry(buffer, attr);
+
+                // If we don't have an entry, we can't register.
+                if (Unsafe.IsNullRef(ref entry))
+                    return false;
+
+                // Get the attr info. If we have one, increment.
+                ref AttrInfo attrInfo = ref FindAttrInfo(attr);
+                if (!Unsafe.IsNullRef(ref attrInfo))
+                {
+                    attrInfo.IncrementCacheCount();
+                    attrInfo.AddCacheSize(buffer.Length);
+                }
+                else
+                {
+                    // Make a new attr info and add it to the list.
+                    // Note: Not using attr info buffer
+                    var newInfo = new AttrInfo(attr.Level, 1, buffer.Length);
+                    AttrList.AddLast(newInfo);
+                }
+
+                TotalCacheSize += buffer.Length;
+                handle = entry.GetHandle();
+                return true;
+            }
+
+            public bool Unregister(out Buffer buffer, CacheHandle handle)
+            {
+                Unsafe.SkipInit(out buffer);
+
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+                Assert.True(!Unsafe.IsNullRef(ref buffer));
+
+                // Find the lower bound for the entry.
+                for (int i = 0; i < EntryCount; i++)
+                {
+                    if (Entries[i].GetHandle() == handle)
+                    {
+                        UnregisterCore(out buffer, ref Entries[i]);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            // ReSharper disable UnusedParameter.Local
+            public bool UnregisterOldest(out Buffer buffer, BufferAttribute attr, int requiredSize = 0)
+            // ReSharper restore UnusedParameter.Local
+            {
+                Unsafe.SkipInit(out buffer);
+
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+                Assert.True(!Unsafe.IsNullRef(ref buffer));
+
+                // If we have no entries, we can't unregister any.
+                if (EntryCount == 0)
+                {
+                    return false;
+                }
+
+                static bool CanUnregister(CacheHandleTable table, ref Entry entry)
+                {
+                    ref AttrInfo attrInfo = ref table.FindAttrInfo(entry.GetBufferAttribute());
+                    Assert.True(!Unsafe.IsNullRef(ref attrInfo));
+
+                    int ccm = table.GetCacheCountMin(entry.GetBufferAttribute());
+                    int csm = table.GetCacheSizeMin(entry.GetBufferAttribute());
+
+                    return ccm < attrInfo.GetCacheCount() && csm + entry.GetSize() <= attrInfo.GetCacheSize();
+                }
+
+                // Find an entry, falling back to the first entry.
+                ref Entry entry = ref Unsafe.NullRef<Entry>();
+                for (int i = 0; i < EntryCount; i++)
+                {
+                    if (CanUnregister(this, ref Entries[i]))
+                    {
+                        entry = ref Entries[i];
+                    }
+                }
+
+                if (Unsafe.IsNullRef(ref entry))
+                {
+                    entry = ref Entries[0];
+                }
+
+                Assert.True(!Unsafe.IsNullRef(ref entry));
+                UnregisterCore(out buffer, ref entry);
+                return true;
+            }
+
+            private void UnregisterCore(out Buffer buffer, ref Entry entry)
+            {
+                Unsafe.SkipInit(out buffer);
+
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+                Assert.True(!Unsafe.IsNullRef(ref buffer));
+                Assert.True(!Unsafe.IsNullRef(ref entry));
+
+                // Get the attribute info.
+                ref AttrInfo attrInfo = ref FindAttrInfo(entry.GetBufferAttribute());
+                Assert.True(!Unsafe.IsNullRef(ref attrInfo));
+                Assert.True(attrInfo.GetCacheCount() > 0);
+                Assert.True(attrInfo.GetCacheSize() >= entry.GetSize());
+
+                // Release from the attr info.
+                attrInfo.DecrementCacheCount();
+                attrInfo.SubtractCacheSize(entry.GetSize());
+
+                // Release from cached size.
+                Assert.True(TotalCacheSize >= entry.GetSize());
+                TotalCacheSize -= entry.GetSize();
+
+                // Release the entry.
+                buffer = entry.GetBuffer();
+                ReleaseEntry(ref entry);
+            }
+
+            public CacheHandle PublishCacheHandle()
+            {
+                Assert.True(Entries != null);
+                return ++CurrentHandle;
+            }
+
+            public int GetTotalCacheSize()
+            {
+                return TotalCacheSize;
+            }
+
+            private ref Entry AcquireEntry(Buffer buffer, BufferAttribute attr)
+            {
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+
+                ref Entry entry = ref Unsafe.NullRef<Entry>();
+                if (EntryCount < EntryCountMax)
+                {
+                    entry = ref Entries[EntryCount];
+                    entry.Initialize(PublishCacheHandle(), buffer, attr);
+                    EntryCount++;
+                    Assert.True(EntryCount == 1 || Entries[EntryCount - 1].GetHandle() < entry.GetHandle());
+                }
+
+                return ref entry;
+            }
+
+            private void ReleaseEntry(ref Entry entry)
+            {
+                // Validate pre-conditions.
+                Assert.True(Entries != null);
+                Assert.True(!Unsafe.IsNullRef(ref entry));
+
+                // Ensure the entry is valid.
+                Span<Entry> entryBuffer = Entries;
+                Assert.True(Unsafe.IsAddressGreaterThan(ref entry, ref MemoryMarshal.GetReference(entryBuffer)));
+                Assert.True(Unsafe.IsAddressLessThan(ref entry,
+                    ref Unsafe.Add(ref MemoryMarshal.GetReference(entryBuffer), entryBuffer.Length)));
+
+                // Get the index of the entry.
+                int index = Unsafe.ByteOffset(ref MemoryMarshal.GetReference(entryBuffer), ref entry).ToInt32() /
+                            Unsafe.SizeOf<Entry>();
+
+                // Copy the entries back by one.
+                Span<Entry> source = entryBuffer.Slice(index + 1, EntryCount - (index + 1));
+                Span<Entry> dest = entryBuffer.Slice(index);
+                source.CopyTo(dest);
+
+                // Decrement our entry count.
+                EntryCount--;
+            }
+
+            private ref AttrInfo FindAttrInfo(BufferAttribute attr)
+            {
+                LinkedListNode<AttrInfo> curNode = AttrList.First;
+
+                while (curNode != null)
+                {
+                    if (curNode.ValueRef.GetLevel() == attr.Level)
+                    {
+                        return ref curNode.ValueRef;
+                    }
+
+                    curNode = curNode.Next;
+                }
+
+                return ref Unsafe.NullRef<AttrInfo>();
+            }
+        }
+
+        private FileSystemBuddyHeap BuddyHeap { get; } = new();
+        private CacheHandleTable CacheTable { get; } = new();
+        private int TotalSize { get; set; }
+        private int PeakFreeSize { get; set; }
+        private int PeakTotalAllocatableSize { get; set; }
+        private int RetriedCount { get; set; }
+        private object Locker { get; } = new();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                BuddyHeap.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public Result Initialize(int maxCacheCount, Memory<byte> heapBuffer, int blockSize, Memory<byte> workBuffer)
+        {
+            // Note: We can't use an external buffer for the cache handle table,
+            // so pass the work buffer directly to the buddy heap.
+            Result rc = CacheTable.Initialize(maxCacheCount);
+            if (rc.IsFailure()) return rc;
+
+            rc = BuddyHeap.Initialize(heapBuffer, blockSize, workBuffer);
+            if (rc.IsFailure()) return rc;
+
+            TotalSize = (int)BuddyHeap.GetTotalFreeSize();
+            PeakFreeSize = TotalSize;
+            PeakTotalAllocatableSize = TotalSize;
+
+            return Result.Success;
+        }
+
+        protected override Buffer DoAllocateBuffer(int size, BufferAttribute attribute)
+        {
+            lock (Locker)
+            {
+                return AllocateBufferImpl(size, attribute);
+            }
+        }
+
+        private Buffer AllocateBufferImpl(int size, BufferAttribute attribute)
+        {
+            int order = BuddyHeap.GetOrderFromBytes((nuint)size);
+            Assert.True(order >= 0);
+
+            // Allocate space on the heap
+            Buffer buffer;
+            while ((buffer = BuddyHeap.AllocateBufferByOrder(order)).IsNull)
+            {
+                // Not enough space in heap. Deallocate cached buffer and try again.
+                RetriedCount++;
+
+                if (!CacheTable.UnregisterOldest(out Buffer deallocateBuffer, attribute, size))
+                {
+                    // No cached buffers left to deallocate.
+                    return Buffer.Empty;
+                }
+                DeallocateBufferImpl(deallocateBuffer);
+            }
+
+            // Successfully allocated a buffer.
+            int allocatedSize = (int)BuddyHeap.GetBytesFromOrder(order);
+            Assert.True(size <= allocatedSize);
+
+            // Update heap stats
+            int freeSize = (int)BuddyHeap.GetTotalFreeSize();
+            PeakFreeSize = Math.Min(PeakFreeSize, freeSize);
+
+            int totalAllocatableSize = freeSize + CacheTable.GetTotalCacheSize();
+            PeakTotalAllocatableSize = Math.Min(PeakTotalAllocatableSize, totalAllocatableSize);
+
+            return buffer;
+        }
+
+        protected override void DoDeallocateBuffer(Buffer buffer)
+        {
+            lock (Locker)
+            {
+                DeallocateBufferImpl(buffer);
+            }
+        }
+
+        private void DeallocateBufferImpl(Buffer buffer)
+        {
+            Assert.True(BitUtil.IsPowerOfTwo(buffer.Length));
+
+            BuddyHeap.Free(buffer);
+        }
+
+        protected override CacheHandle DoRegisterCache(Buffer buffer, BufferAttribute attribute)
+        {
+            lock (Locker)
+            {
+                return RegisterCacheImpl(buffer, attribute);
+            }
+        }
+
+        private CacheHandle RegisterCacheImpl(Buffer buffer, BufferAttribute attribute)
+        {
+            CacheHandle handle;
+
+            // Try to register the handle.
+            while (!CacheTable.Register(out handle, buffer, attribute))
+            {
+                // Unregister a buffer and try registering again.
+                RetriedCount++;
+                if (!CacheTable.UnregisterOldest(out Buffer deallocateBuffer, attribute))
+                {
+                    // Can't unregister any existing buffers.
+                    // Register the input buffer to /dev/null.
+                    DeallocateBufferImpl(buffer);
+                    return CacheTable.PublishCacheHandle();
+                }
+
+                // Deallocate the unregistered buffer.
+                DeallocateBufferImpl(deallocateBuffer);
+            }
+
+            return handle;
+        }
+
+        protected override Buffer DoAcquireCache(CacheHandle handle)
+        {
+            lock (Locker)
+            {
+                return AcquireCacheImpl(handle);
+            }
+        }
+
+        private Buffer AcquireCacheImpl(CacheHandle handle)
+        {
+            if (CacheTable.Unregister(out Buffer range, handle))
+            {
+                int totalAllocatableSize = (int)BuddyHeap.GetTotalFreeSize() + CacheTable.GetTotalCacheSize();
+                PeakTotalAllocatableSize = Math.Min(PeakTotalAllocatableSize, totalAllocatableSize);
+            }
+            else
+            {
+                range = Buffer.Empty;
+            }
+
+            return range;
+        }
+
+        protected override int DoGetTotalSize()
+        {
+            return TotalSize;
+        }
+
+        protected override int DoGetFreeSize()
+        {
+            lock (Locker)
+            {
+                return GetFreeSizeImpl();
+            }
+        }
+
+        private int GetFreeSizeImpl()
+        {
+            return (int)BuddyHeap.GetTotalFreeSize();
+        }
+
+        protected override int DoGetTotalAllocatableSize()
+        {
+            lock (Locker)
+            {
+                return GetTotalAllocatableSizeImpl();
+            }
+        }
+
+        private int GetTotalAllocatableSizeImpl()
+        {
+            return GetFreeSizeImpl() + CacheTable.GetTotalCacheSize();
+        }
+
+        protected override int DoGetFreeSizePeak()
+        {
+            lock (Locker)
+            {
+                return GetFreeSizePeakImpl();
+            }
+        }
+
+        private int GetFreeSizePeakImpl()
+        {
+            return PeakFreeSize;
+        }
+
+        protected override int DoGetTotalAllocatableSizePeak()
+        {
+            lock (Locker)
+            {
+                return GetTotalAllocatableSizePeakImpl();
+            }
+        }
+
+        private int GetTotalAllocatableSizePeakImpl()
+        {
+            return PeakTotalAllocatableSize;
+        }
+
+        protected override int DoGetRetriedCount()
+        {
+            lock (Locker)
+            {
+                return GetRetriedCountImpl();
+            }
+        }
+
+        private int GetRetriedCountImpl()
+        {
+            return RetriedCount;
+        }
+
+        protected override void DoClearPeak()
+        {
+            lock (Locker)
+            {
+                ClearPeakImpl();
+            }
+        }
+
+        private void ClearPeakImpl()
+        {
+            PeakFreeSize = GetFreeSizeImpl();
+            PeakTotalAllocatableSize = GetTotalAllocatableSizeImpl();
+            RetriedCount = 0;
+        }
+    }
+}

--- a/src/LibHac/FsSystem/ConcatenationFile.cs
+++ b/src/LibHac/FsSystem/ConcatenationFile.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -227,7 +228,7 @@ namespace LibHac.FsSystem
 
             if (size == 0) return 1;
 
-            return (int)Utilities.DivideByRoundUp(size, subFileSize);
+            return (int)BitUtil.DivideUp(size, subFileSize);
         }
 
         private static long QuerySubFileSize(int subFileIndex, long totalSize, long subFileSize)

--- a/src/LibHac/FsSystem/HierarchicalIntegrityVerificationStorage.cs
+++ b/src/LibHac/FsSystem/HierarchicalIntegrityVerificationStorage.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -37,7 +38,7 @@ namespace LibHac.FsSystem
                 var levelData = new IntegrityVerificationStorage(levelInfo[i], Levels[i - 1], integrityCheckLevel, leaveOpen);
                 levelData.GetSize(out long levelSize).ThrowIfFailure();
 
-                int cacheCount = Math.Min((int)Utilities.DivideByRoundUp(levelSize, levelInfo[i].BlockSize), 4);
+                int cacheCount = Math.Min((int)BitUtil.DivideUp(levelSize, levelInfo[i].BlockSize), 4);
 
                 Levels[i] = new CachedStorage(levelData, cacheCount, leaveOpen);
                 LevelValidities[i - 1] = levelData.BlockValidities;
@@ -145,7 +146,7 @@ namespace LibHac.FsSystem
             IntegrityVerificationStorage storage = IntegrityStorages[IntegrityStorages.Length - 1];
 
             long blockSize = storage.SectorSize;
-            int blockCount = (int)Utilities.DivideByRoundUp(Length, blockSize);
+            int blockCount = (int)BitUtil.DivideUp(Length, blockSize);
 
             var buffer = new byte[blockSize];
             var result = Validity.Valid;

--- a/src/LibHac/FsSystem/IndirectStorage.cs
+++ b/src/LibHac/FsSystem/IndirectStorage.cs
@@ -84,9 +84,9 @@ namespace LibHac.FsSystem
         public Result GetEntryList(Span<Entry> entryBuffer, out int outputEntryCount, long offset, long size)
         {
             // Validate pre-conditions
-            Assert.AssertTrue(offset >= 0);
-            Assert.AssertTrue(size >= 0);
-            Assert.AssertTrue(IsInitialized());
+            Assert.True(offset >= 0);
+            Assert.True(size >= 0);
+            Assert.True(IsInitialized());
 
             // Clear the out count
             outputEntryCount = 0;
@@ -153,8 +153,8 @@ namespace LibHac.FsSystem
         protected override unsafe Result DoRead(long offset, Span<byte> destination)
         {
             // Validate pre-conditions
-            Assert.AssertTrue(offset >= 0);
-            Assert.AssertTrue(IsInitialized());
+            Assert.True(offset >= 0);
+            Assert.True(IsInitialized());
 
             // Succeed if there's nothing to read
             if (destination.Length == 0)
@@ -206,9 +206,9 @@ namespace LibHac.FsSystem
         private Result OperatePerEntry(long offset, long size, OperateFunc func)
         {
             // Validate preconditions
-            Assert.AssertTrue(offset >= 0);
-            Assert.AssertTrue(size >= 0);
-            Assert.AssertTrue(IsInitialized());
+            Assert.True(offset >= 0);
+            Assert.True(size >= 0);
+            Assert.True(IsInitialized());
 
             // Succeed if there's nothing to operate on
             if (size == 0)
@@ -272,12 +272,12 @@ namespace LibHac.FsSystem
                     // Get the offset of the entry in the data we read
                     long dataOffset = currentOffset - currentEntryOffset;
                     long dataSize = nextEntryOffset - currentEntryOffset - dataOffset;
-                    Assert.AssertTrue(dataSize > 0);
+                    Assert.True(dataSize > 0);
 
                     // Determine how much is left
                     long remainingSize = endOffset - currentOffset;
                     long currentSize = Math.Min(remainingSize, dataSize);
-                    Assert.AssertTrue(currentSize <= size);
+                    Assert.True(currentSize <= size);
 
                     {
                         SubStorage currentStorage = DataStorage[currentEntry.StorageIndex];

--- a/src/LibHac/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/FsSystem/NcaUtils/Nca.cs
@@ -150,7 +150,7 @@ namespace LibHac.FsSystem.NcaUtils
 
             BaseStorage.GetSize(out long baseSize).ThrowIfFailure();
 
-            if (!Utilities.IsSubRange(offset, size, baseSize))
+            if (!IsSubRange(offset, size, baseSize))
             {
                 throw new InvalidDataException(
                     $"Section offset (0x{offset:x}) and length (0x{size:x}) fall outside the total NCA length (0x{baseSize:x}).");
@@ -693,7 +693,7 @@ namespace LibHac.FsSystem.NcaUtils
 
             bodyStorage.GetSize(out long baseSize).ThrowIfFailure();
 
-            if (!Utilities.IsSubRange(offset, size, baseSize))
+            if (!IsSubRange(offset, size, baseSize))
             {
                 throw new InvalidDataException(
                     $"Section offset (0x{offset + 0x400:x}) and length (0x{size:x}) fall outside the total NCA length (0x{baseSize + 0x400:x}).");
@@ -762,6 +762,12 @@ namespace LibHac.FsSystem.NcaUtils
 
             header.CounterType = counterType;
             header.CounterVersion = counterVersion;
+        }
+
+        private static bool IsSubRange(long startIndex, long subLength, long length)
+        {
+            bool isOutOfRange = startIndex < 0 || startIndex > length || subLength < 0 || startIndex > length - subLength;
+            return !isOutOfRange;
         }
     }
 }

--- a/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
+++ b/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
@@ -254,7 +254,7 @@ namespace LibHac.FsSystem.NcaUtils
 
         private static bool CheckIfDecrypted(ReadOnlySpan<byte> header)
         {
-            Assert.AssertTrue(header.Length >= 0x400);
+            Assert.True(header.Length >= 0x400);
 
             // Check the magic value
             if (header[0x200] != 'N' || header[0x201] != 'C' || header[0x202] != 'A')

--- a/src/LibHac/FsSystem/PartitionFileSystemBuilder.cs
+++ b/src/LibHac/FsSystem/PartitionFileSystemBuilder.cs
@@ -7,6 +7,7 @@ using LibHac.Common;
 using LibHac.Crypto;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -121,7 +122,7 @@ namespace LibHac.FsSystem
                 size += entry.NameLength + 1;
             }
 
-            int endOffset = Utilities.AlignUp(startOffset + size, GetMetaDataAlignment(type));
+            int endOffset = Alignment.AlignUpPow2(startOffset + size, GetMetaDataAlignment(type));
             return endOffset - startOffset;
         }
 
@@ -135,7 +136,7 @@ namespace LibHac.FsSystem
             }
         }
 
-        private int GetMetaDataAlignment(PartitionFileSystemType type)
+        private uint GetMetaDataAlignment(PartitionFileSystemType type)
         {
             switch (type)
             {

--- a/src/LibHac/FsSystem/PooledBuffer.cs
+++ b/src/LibHac/FsSystem/PooledBuffer.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Buffers;
+using LibHac.Diag;
+
+namespace LibHac.FsSystem
+{
+    // Implement the PooledBuffer interface using .NET ArrayPools
+    public struct PooledBuffer : IDisposable
+    {
+        // It's faster to create new smaller arrays than rent them
+        private const int RentThresholdBytes = 512;
+
+        private const int HeapBlockSize = 1024 * 4;
+
+        // Keep the max sizes that FS uses.
+        // A heap block is 4KB.An order is a power of two. 
+        // This gives blocks of the order 512KB, 4MB.
+        private const int HeapOrderMax = 7;
+        private const int HeapOrderMaxForLarge = HeapOrderMax + 3;
+
+        private const int HeapAllocatableSizeMax = HeapBlockSize * (1 << HeapOrderMax);
+        private const int HeapAllocatableSizeMaxForLarge = HeapBlockSize * (1 << HeapOrderMaxForLarge);
+
+        private byte[] Array { get; set; }
+        private int Length { get; set; }
+
+        public PooledBuffer(int idealSize, int requiredSize)
+        {
+            Array = null;
+            Length = default;
+            Allocate(idealSize, requiredSize);
+        }
+
+        public Span<byte> GetBuffer()
+        {
+            Assert.NotNull(Array);
+            return Array.AsSpan(0, Length);
+        }
+
+        public int GetSize()
+        {
+            Assert.NotNull(Array);
+            return Length;
+        }
+
+        public static int GetAllocatableSizeMax() => GetAllocatableSizeMaxCore(false);
+        public static int GetAllocatableParticularlyLargeSizeMax => GetAllocatableSizeMaxCore(true);
+
+        private static int GetAllocatableSizeMaxCore(bool enableLargeCapacity)
+        {
+            return enableLargeCapacity ? HeapAllocatableSizeMaxForLarge : HeapAllocatableSizeMax;
+        }
+
+        public void Allocate(int idealSize, int requiredSize) => AllocateCore(idealSize, requiredSize, false);
+        public void AllocateParticularlyLarge(int idealSize, int requiredSize) => AllocateCore(idealSize, requiredSize, true);
+
+        private void AllocateCore(int idealSize, int requiredSize, bool enableLargeCapacity)
+        {
+            Assert.Null(Array);
+
+            // Check that we can allocate this size.
+            Assert.True(requiredSize <= GetAllocatableSizeMaxCore(enableLargeCapacity));
+
+            int targetSize = Math.Min(Math.Max(idealSize, requiredSize),
+                GetAllocatableSizeMaxCore(enableLargeCapacity));
+
+            if (targetSize >= RentThresholdBytes)
+            {
+                Array = ArrayPool<byte>.Shared.Rent(targetSize);
+            }
+            else
+            {
+                Array = new byte[targetSize];
+            }
+
+            Length = Array.Length;
+        }
+
+        public void Deallocate()
+        {
+            // Shrink the buffer to empty.
+            Shrink(0);
+            Assert.Null(Array);
+        }
+
+        public void Shrink(int idealSize)
+        {
+            Assert.True(idealSize <= GetAllocatableSizeMaxCore(true));
+
+            // Check if we actually need to shrink.
+            if (Length > idealSize)
+            {
+                Assert.NotNull(Array);
+
+                // Pretend we shrank the buffer.
+                Length = idealSize;
+
+                // Shrinking to zero means that we have no buffer.
+                if (Length == 0)
+                {
+                    // Return the array if we rented it.
+                    if (Array?.Length >= RentThresholdBytes)
+                    {
+                        ArrayPool<byte>.Shared.Return(Array);
+                    }
+
+                    Array = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Deallocate();
+        }
+    }
+}

--- a/src/LibHac/FsSystem/RomFs/RomFsBuilder.cs
+++ b/src/LibHac/FsSystem/RomFs/RomFsBuilder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem.RomFs
 {
@@ -61,7 +62,7 @@ namespace LibHac.FsSystem.RomFs
             Sources.Add(fileStorage);
 
             long newOffset = CurrentOffset + fileSize;
-            CurrentOffset = Utilities.AlignUp(newOffset, FileAlignment);
+            CurrentOffset = Alignment.AlignUp(newOffset, FileAlignment);
 
             var padding = new NullStorage(CurrentOffset - newOffset);
             Sources.Add(padding);

--- a/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
+++ b/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
@@ -7,9 +7,7 @@ using LibHac.Util;
 
 namespace LibHac.FsSystem.RomFs
 {
-    // todo: Change constraint to "unmanaged" after updating to
-    // a newer SDK https://github.com/dotnet/csharplang/issues/1937
-    internal class RomFsDictionary<T> where T : struct
+    internal class RomFsDictionary<T> where T : unmanaged
     {
         private int _count;
         private int _length;
@@ -194,7 +192,7 @@ namespace LibHac.FsSystem.RomFs
             if (value != _capacity)
             {
                 var newBuffer = new byte[value];
-                Buffer.BlockCopy(Entries, 0, newBuffer, 0, _length);
+                System.Buffer.BlockCopy(Entries, 0, newBuffer, 0, _length);
 
                 Entries = newBuffer;
                 _capacity = value;

--- a/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
+++ b/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem.RomFs
 {
@@ -140,7 +141,7 @@ namespace LibHac.FsSystem.RomFs
 
         private int CreateNewEntry(int nameLength)
         {
-            int bytesNeeded = Utilities.AlignUp(_sizeOfEntry + nameLength, 4);
+            int bytesNeeded = Alignment.AlignUp(_sizeOfEntry + nameLength, 4);
 
             if (_length + bytesNeeded > _capacity)
             {

--- a/src/LibHac/FsSystem/Save/AllocationTableStorage.cs
+++ b/src/LibHac/FsSystem/Save/AllocationTableStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem.Save
 {
@@ -104,8 +105,8 @@ namespace LibHac.FsSystem.Save
 
         protected override Result DoSetSize(long size)
         {
-            int oldBlockCount = (int)Utilities.DivideByRoundUp(_length, BlockSize);
-            int newBlockCount = (int)Utilities.DivideByRoundUp(size, BlockSize);
+            int oldBlockCount = (int)BitUtil.DivideUp(_length, BlockSize);
+            int newBlockCount = (int)BitUtil.DivideUp(size, BlockSize);
 
             if (oldBlockCount == newBlockCount) return Result.Success;
 

--- a/src/LibHac/FsSystem/Save/BufferedStorage.cs
+++ b/src/LibHac/FsSystem/Save/BufferedStorage.cs
@@ -1,0 +1,1716 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using LibHac.Common;
+using LibHac.Diag;
+using LibHac.Fs;
+using LibHac.FsSystem.Buffers;
+using LibHac.Util;
+using Buffer = LibHac.Fs.Buffer;
+using CacheHandle = System.Int64;
+
+namespace LibHac.FsSystem.Save
+{
+    /// <summary>
+    /// An <see cref="IStorage"/> that provides buffered access to a base <see cref="IStorage"/>.
+    /// </summary>
+    public class BufferedStorage : IStorage
+    {
+        private const long InvalidOffset = long.MaxValue;
+        private const int InvalidIndex = -1;
+
+        /// <summary>
+        /// Caches a single block of data for a <see cref="Save.BufferedStorage"/>
+        /// </summary>
+        private struct Cache : IDisposable
+        {
+            private ref struct FetchParameter
+            {
+                public long Offset;
+                public Span<byte> Buffer;
+            }
+
+            private BufferedStorage BufferedStorage { get; set; }
+            private Buffer MemoryRange { get; set; }
+            private CacheHandle CacheHandle { get; set; }
+            private long Offset { get; set; }
+            private bool _isValid;
+            private bool _isDirty;
+            private int ReferenceCount { get; set; }
+            private int Index { get; set; }
+            private int NextIndex { get; set; }
+            private int PrevIndex { get; set; }
+
+            private ref Cache Next => ref BufferedStorage.Caches[NextIndex];
+            private ref Cache Prev => ref BufferedStorage.Caches[PrevIndex];
+
+            public void Dispose()
+            {
+                FinalizeObject();
+            }
+
+            public void Initialize(BufferedStorage bufferedStorage, int index)
+            {
+                // Note: C# can't have default constructors on structs, so the default constructor code was
+                // moved into Initialize since Initialize is always called right after the constructor.
+                Offset = InvalidOffset;
+                ReferenceCount = 1;
+                Index = index;
+                NextIndex = InvalidIndex;
+                PrevIndex = InvalidIndex;
+                // End default constructor code
+
+                Assert.NotNull(bufferedStorage);
+                Assert.True(BufferedStorage == null);
+
+                BufferedStorage = bufferedStorage;
+                Link();
+            }
+
+            public void FinalizeObject()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.Equal(0, ReferenceCount);
+
+                // If we're valid, acquire our cache handle and free our buffer.
+                if (IsValid())
+                {
+                    IBufferManager bufferManager = BufferedStorage.BufferManager;
+                    if (!_isDirty)
+                    {
+                        Assert.True(MemoryRange.IsNull);
+                        MemoryRange = bufferManager.AcquireCache(CacheHandle);
+                    }
+
+                    if (!MemoryRange.IsNull)
+                    {
+                        bufferManager.DeallocateBuffer(MemoryRange);
+                        MemoryRange = Buffer.Empty;
+                    }
+                }
+
+                // Clear all our members.
+                BufferedStorage = null;
+                Offset = InvalidOffset;
+                _isValid = false;
+                _isDirty = false;
+                NextIndex = InvalidIndex;
+                PrevIndex = InvalidIndex;
+            }
+
+            /// <summary>
+            /// Decrements the ref-count and adds the <see cref="Cache"/> to its <see cref="Save.BufferedStorage"/>'s
+            /// fetch list if the <see cref="Cache"/> has no more references, and registering the buffer with
+            /// the <see cref="IBufferManager"/> if not dirty.
+            /// </summary>
+            public void Link()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(ReferenceCount > 0);
+
+                ReferenceCount--;
+                if (ReferenceCount == 0)
+                {
+                    Assert.True(NextIndex == InvalidIndex);
+                    Assert.True(PrevIndex == InvalidIndex);
+
+                    // If the fetch list is empty we can simply add it as the only cache in the list.
+                    if (BufferedStorage.NextFetchCacheIndex == InvalidIndex)
+                    {
+                        BufferedStorage.NextFetchCacheIndex = Index;
+                        NextIndex = Index;
+                        PrevIndex = Index;
+                    }
+                    else
+                    {
+                        // Check against a cache being registered twice.
+                        ref Cache cache = ref BufferedStorage.NextFetchCache;
+                        do
+                        {
+                            if (cache.IsValid() && Hits(cache.Offset, BufferedStorage.BlockSize))
+                            {
+                                _isValid = false;
+                                break;
+                            }
+
+                            cache = ref cache.Next;
+                        } while (cache.Index != BufferedStorage.NextFetchCacheIndex);
+
+                        // Verify the end of the fetch list loops back to the start.
+                        Assert.True(BufferedStorage.NextFetchCache.PrevIndex != InvalidIndex);
+                        Assert.Equal(BufferedStorage.NextFetchCache.Prev.NextIndex,
+                            BufferedStorage.NextFetchCacheIndex);
+
+                        // Link into the fetch list.
+                        NextIndex = BufferedStorage.NextFetchCacheIndex;
+                        PrevIndex = BufferedStorage.NextFetchCache.PrevIndex;
+                        Next.PrevIndex = Index;
+                        Prev.NextIndex = Index;
+
+                        // Insert invalid caches at the start of the list so they'll
+                        // be used first when a fetch cache is needed.
+                        if (!IsValid())
+                            BufferedStorage.NextFetchCacheIndex = Index;
+                    }
+
+                    // If we're not valid, clear our offset.
+                    if (!IsValid())
+                    {
+                        Offset = InvalidOffset;
+                        _isDirty = false;
+                    }
+
+                    // Ensure our buffer state is coherent.
+                    // We can let go of our buffer if it's not dirty, allowing the buffer to be used elsewhere if needed.
+                    if (!MemoryRange.IsNull && !IsDirty())
+                    {
+                        // If we're valid, register the buffer with the buffer manager for possible later retrieval.
+                        // Otherwise the the data in the buffer isn't needed, so deallocate it.
+                        if (IsValid())
+                        {
+                            CacheHandle = BufferedStorage.BufferManager.RegisterCache(MemoryRange,
+                                new IBufferManager.BufferAttribute());
+                        }
+                        else
+                        {
+                            BufferedStorage.BufferManager.DeallocateBuffer(MemoryRange);
+                        }
+
+                        MemoryRange = default;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Increments the ref-count and removes the <see cref="Cache"/> from its
+            /// <see cref="Save.BufferedStorage"/>'s fetch list if needed.
+            /// </summary>
+            public void Unlink()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.True(ReferenceCount >= 0);
+
+                ReferenceCount++;
+                if (ReferenceCount == 1)
+                {
+                    // If we're the first to grab this Cache, the Cache should be in the BufferedStorage's fetch list.
+                    Assert.True(NextIndex != InvalidIndex);
+                    Assert.True(PrevIndex != InvalidIndex);
+                    Assert.True(Next.PrevIndex == Index);
+                    Assert.True(Prev.NextIndex == Index);
+
+                    // Set the new fetch list head if this Cache is the current head
+                    if (BufferedStorage.NextFetchCacheIndex == Index)
+                    {
+                        if (NextIndex != Index)
+                        {
+                            BufferedStorage.NextFetchCacheIndex = NextIndex;
+                        }
+                        else
+                        {
+                            BufferedStorage.NextFetchCacheIndex = InvalidIndex;
+                        }
+                    }
+
+                    BufferedStorage.NextAcquireCacheIndex = Index;
+
+                    Next.PrevIndex = PrevIndex;
+                    Prev.NextIndex = NextIndex;
+                    NextIndex = InvalidIndex;
+                    PrevIndex = InvalidIndex;
+                }
+                else
+                {
+                    Assert.True(NextIndex == InvalidIndex);
+                    Assert.True(PrevIndex == InvalidIndex);
+                }
+            }
+
+            /// <summary>
+            /// Reads the data from the base <see cref="IStorage"/> contained in this <see cref="Cache"/>'s buffer.
+            /// The <see cref="Cache"/> must contain valid data before calling, and the <paramref name="offset"/>
+            /// must be inside the block of data held by this <see cref="Cache"/>.
+            /// </summary>
+            /// <param name="offset">The offset in the base <see cref="IStorage"/> to be read from.</param>
+            /// <param name="buffer">The buffer in which to place the read data.</param>
+            public void Read(long offset, Span<byte> buffer)
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(IsValid());
+                Assert.True(Hits(offset, 1));
+                Assert.True(!MemoryRange.IsNull);
+
+                long readOffset = offset - Offset;
+                long readableOffsetMax = BufferedStorage.BlockSize - buffer.Length;
+
+                Assert.True(readOffset >= 0);
+                Assert.True(readOffset <= readableOffsetMax);
+
+                Span<byte> cacheBuffer = MemoryRange.Span.Slice((int)readOffset, buffer.Length);
+                cacheBuffer.CopyTo(buffer);
+            }
+
+            /// <summary>
+            /// Buffers data to be written to the base <see cref="IStorage"/> when this <see cref="Cache"/> is flushed.
+            /// The <see cref="Cache"/> must contain valid data before calling, and the <paramref name="offset"/>
+            /// must be inside the block of data held by this <see cref="Cache"/>.
+            /// </summary>
+            /// <param name="offset">The offset in the base <see cref="IStorage"/> to be written to.</param>
+            /// <param name="buffer">The buffer containing the data to be written.</param>
+            public void Write(long offset, ReadOnlySpan<byte> buffer)
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(IsValid());
+                Assert.True(Hits(offset, 1));
+                Assert.True(!MemoryRange.IsNull);
+
+                long writeOffset = offset - Offset;
+                long writableOffsetMax = BufferedStorage.BlockSize - buffer.Length;
+
+                Assert.True(writeOffset >= 0);
+                Assert.True(writeOffset <= writableOffsetMax);
+
+                Span<byte> cacheBuffer = MemoryRange.Span.Slice((int)writeOffset, buffer.Length);
+                buffer.CopyTo(cacheBuffer);
+                _isDirty = true;
+            }
+
+            /// <summary>
+            /// If this <see cref="Cache"/> is dirty, flushes its data to the base <see cref="IStorage"/>.
+            /// The <see cref="Cache"/> must contain valid data before calling.
+            /// </summary>
+            /// <returns>The <see cref="Result"/> of the operation.</returns>
+            public Result Flush()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(IsValid());
+
+                if (_isDirty)
+                {
+                    Assert.True(!MemoryRange.IsNull);
+
+                    long baseSize = BufferedStorage.BaseStorageSize;
+                    long blockSize = BufferedStorage.BlockSize;
+                    long flushSize = Math.Min(blockSize, baseSize - Offset);
+
+                    SubStorage baseStorage = BufferedStorage.BaseStorage;
+                    Span<byte> cacheBuffer = MemoryRange.Span;
+                    Assert.True(flushSize == cacheBuffer.Length);
+
+                    Result rc = baseStorage.Write(Offset, cacheBuffer);
+                    if (rc.IsFailure()) return rc;
+
+                    _isDirty = false;
+
+                    BufferManagerUtility.EnableBlockingBufferManagerAllocation();
+                }
+
+                return Result.Success;
+            }
+
+            /// <summary>
+            /// Prepares this <see cref="Cache"/> to fetch a new block from the base <see cref="IStorage"/>.
+            /// If the caller has the only reference to this Cache,
+            /// the Cache's buffer will be flushed and the Cache invalidated. While the Cache is
+            /// prepared to fetch, <see cref="SharedCache"/> will skip it when iterating all the Caches.
+            /// </summary>
+            /// <returns>The <see cref="Result"/> of any attempted flush, and <see langword="true"/> if the
+            /// <see cref="Cache"/> is prepared to fetch; <see langword="false"/> if not.</returns>
+            public (Result Result, bool IsPrepared) PrepareFetch()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(IsValid());
+                Assert.True(Monitor.IsEntered(BufferedStorage.Locker));
+
+                (Result Result, bool IsPrepared) result = (Result.Success, false);
+
+                if (ReferenceCount == 1)
+                {
+                    result.Result = Flush();
+
+                    if (result.Result.IsSuccess())
+                    {
+                        _isValid = false;
+                        ReferenceCount = 0;
+                        result.IsPrepared = true;
+                    }
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Marks the <see cref="Cache"/> as unprepared to cache a new block,
+            /// allowing <see cref="SharedCache"/> to acquire it while iterating.
+            /// </summary>
+            public void UnprepareFetch()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(!IsValid());
+                Assert.True(!_isDirty);
+                Assert.True(Monitor.IsEntered(BufferedStorage.Locker));
+
+                _isValid = true;
+                ReferenceCount = 1;
+            }
+
+            /// <summary>
+            /// Reads the storage block containing the specified offset into this <see cref="Cache"/>'s buffer.
+            /// </summary>
+            /// <param name="offset">An offset in the block to fetch.</param>
+            /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+            /// <see cref="ResultFs.BufferAllocationFailed"/>: A buffer could not be allocated.</returns>
+            public Result Fetch(long offset)
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(!IsValid());
+                Assert.True(!_isDirty);
+
+                Result rc;
+
+                // Make sure this Cache has an allocated buffer
+                if (MemoryRange.IsNull)
+                {
+                    rc = AllocateFetchBuffer();
+                    if (rc.IsFailure()) return rc;
+                }
+
+                CalcFetchParameter(out FetchParameter fetchParam, offset);
+
+                rc = BufferedStorage.BaseStorage.Read(fetchParam.Offset, fetchParam.Buffer);
+                if (rc.IsFailure()) return rc;
+
+                Offset = fetchParam.Offset;
+                Assert.True(Hits(offset, 1));
+
+                return Result.Success;
+            }
+
+            /// <summary>
+            /// Fills this <see cref="Cache"/>'s buffer from an input buffer containing a block of data
+            /// read from the base <see cref="IStorage"/>.
+            /// </summary>
+            /// <param name="offset">The start offset of the block in the base <see cref="IStorage"/>
+            /// that the data was read from.</param>
+            /// <param name="buffer">A buffer containing the data read from the base <see cref="IStorage"/>.</param>
+            /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+            /// <see cref="ResultFs.BufferAllocationFailed"/>: A buffer could not be allocated.</returns>
+            public Result FetchFromBuffer(long offset, ReadOnlySpan<byte> buffer)
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(NextIndex == InvalidIndex);
+                Assert.True(PrevIndex == InvalidIndex);
+                Assert.True(!IsValid());
+                Assert.True(!_isDirty);
+                Assert.True(Alignment.IsAlignedPow2(offset, (uint)BufferedStorage.BlockSize));
+
+                // Make sure this Cache has an allocated buffer
+                if (MemoryRange.IsNull)
+                {
+                    Result rc = AllocateFetchBuffer();
+                    if (rc.IsFailure()) return rc;
+                }
+
+                CalcFetchParameter(out FetchParameter fetchParam, offset);
+                Assert.Equal(fetchParam.Offset, offset);
+                Assert.True(fetchParam.Buffer.Length <= buffer.Length);
+
+                buffer.Slice(0, fetchParam.Buffer.Length).CopyTo(fetchParam.Buffer);
+                Offset = fetchParam.Offset;
+                Assert.True(Hits(offset, 1));
+
+                return Result.Success;
+            }
+
+            /// <summary>
+            /// Tries to retrieve the cache's memory buffer from the <see cref="IBufferManager"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if the memory buffer was available.
+            /// <see langword="false"/> if the buffer has been evicted from the <see cref="IBufferManager"/> cache.</returns>
+            public bool TryAcquireCache()
+            {
+                Assert.NotNull(BufferedStorage);
+                Assert.NotNull(BufferedStorage.BufferManager);
+                Assert.True(IsValid());
+
+                if (!MemoryRange.IsNull)
+                    return true;
+
+                MemoryRange = BufferedStorage.BufferManager.AcquireCache(CacheHandle);
+                _isValid = !MemoryRange.IsNull;
+                return _isValid;
+            }
+
+            /// <summary>
+            /// Invalidates the data in this <see cref="Cache"/>.
+            /// </summary>
+            public void Invalidate()
+            {
+                Assert.NotNull(BufferedStorage);
+                _isValid = false;
+            }
+
+            /// <summary>
+            /// Does this <see cref="Cache"/> have a valid buffer or are there any references to this Cache?
+            /// </summary>
+            /// <returns><see langword="true"/> if this <see cref="Cache"/> has a valid buffer
+            /// or if anybody currently has a reference to this Cache. Otherwise, <see langword="false"/>.</returns>
+            public bool IsValid()
+            {
+                Assert.NotNull(BufferedStorage);
+
+                return _isValid || ReferenceCount > 0;
+            }
+
+            /// <summary>
+            /// Does this <see cref="Cache"/> have modified data that needs
+            /// to be flushed to the base <see cref="IStorage"/>?
+            /// </summary>
+            /// <returns><see langword="true"/> if this <see cref="Cache"/> has unflushed data.
+            /// Otherwise, <see langword="false"/>.</returns>
+            public bool IsDirty()
+            {
+                Assert.NotNull(BufferedStorage);
+
+                return _isDirty;
+            }
+
+            /// <summary>
+            /// Checks if the <see cref="Cache"/> covers any of the specified range.
+            /// </summary>
+            /// <param name="offset">The start offset of the range to check.</param>
+            /// <param name="size">The size of the range to check.</param>
+            /// <returns><see langword="true"/> if this <see cref="Cache"/>'s range covers any of the input range.
+            /// Otherwise, <see langword="false"/>.</returns>
+            public bool Hits(long offset, long size)
+            {
+                Assert.NotNull(BufferedStorage);
+
+                long blockSize = BufferedStorage.BlockSize;
+                return (offset < Offset + blockSize) && (Offset < offset + size);
+            }
+
+            /// <summary>
+            /// Allocates a buffer for this <see cref="Cache"/>.
+            /// Should only be called when there is not already an allocated buffer.
+            /// </summary>
+            /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+            /// <see cref="ResultFs.BufferAllocationFailed"/>: A buffer could not be allocated.</returns>
+            private Result AllocateFetchBuffer()
+            {
+                IBufferManager bufferManager = BufferedStorage.BufferManager;
+                Assert.True(bufferManager.AcquireCache(CacheHandle).IsNull);
+
+                Result rc = BufferManagerUtility.AllocateBufferUsingBufferManagerContext(out Buffer bufferTemp,
+                    bufferManager, (int)BufferedStorage.BlockSize, new IBufferManager.BufferAttribute(),
+                    static (in Buffer buffer) => !buffer.IsNull);
+
+                // Clear the current MemoryRange if allocation failed.
+                MemoryRange = rc.IsSuccess() ? bufferTemp : default;
+                return Result.Success;
+            }
+
+            /// <summary>
+            /// Calculates the parameters used to fetch the block containing the
+            /// specified offset in the base <see cref="IStorage"/>.
+            /// </summary>
+            /// <param name="fetchParam">When this function returns, contains
+            /// the parameters that can be used to fetch the block.</param>
+            /// <param name="offset">The offset to be fetched.</param>
+            private void CalcFetchParameter(out FetchParameter fetchParam, long offset)
+            {
+                long blockSize = BufferedStorage.BlockSize;
+                long storageOffset = Alignment.AlignDownPow2(offset, (uint)BufferedStorage.BlockSize);
+                long baseSize = BufferedStorage.BaseStorageSize;
+                long remainingSize = baseSize - storageOffset;
+                long cacheSize = Math.Min(blockSize, remainingSize);
+                Span<byte> cacheBuffer = MemoryRange.Span.Slice(0, (int)cacheSize);
+
+                Assert.True(offset >= 0);
+                Assert.True(offset < baseSize);
+
+                fetchParam = new FetchParameter
+                {
+                    Offset = storageOffset,
+                    Buffer = cacheBuffer
+                };
+            }
+        }
+
+        /// <summary>
+        /// Allows iteration over the <see cref="Save.BufferedStorage.Cache"/> in a <see cref="Save.BufferedStorage"/>.
+        /// Several options exist for which Caches to iterate.
+        /// </summary>
+        private ref struct SharedCache
+        {
+            // ReSharper disable once MemberHidesStaticFromOuterClass
+            public Ref<Cache> Cache { get; private set; }
+            private Ref<Cache> StartCache { get; }
+            public BufferedStorage BufferedStorage { get; }
+
+            public SharedCache(BufferedStorage bufferedStorage)
+            {
+                Assert.NotNull(bufferedStorage);
+                Cache = default;
+                StartCache = new Ref<Cache>(ref bufferedStorage.NextAcquireCache);
+                BufferedStorage = bufferedStorage;
+            }
+
+            public void Dispose()
+            {
+                lock (BufferedStorage.Locker)
+                {
+                    Release();
+                }
+            }
+
+            /// <summary>
+            /// Moves to the next <see cref="Save.BufferedStorage.Cache"/> that contains data from the specified range.
+            /// </summary>
+            /// <param name="offset">The start offset of the range.</param>
+            /// <param name="size">The size of the range.</param>
+            /// <returns><see langword="true"/> if a <see cref="Save.BufferedStorage.Cache"/> from the
+            /// specified range was found. <see langword="false"/> if no matching Caches exist,
+            /// or if all matching Caches have already been iterated.</returns>
+            public bool AcquireNextOverlappedCache(long offset, long size)
+            {
+                Assert.NotNull(BufferedStorage);
+
+                bool isFirst = Cache.IsNull;
+                ref Cache start = ref isFirst ? ref StartCache.Value : ref Unsafe.Add(ref Cache.Value, 1);
+
+                // Make sure the Cache instance is in-range.
+                Assert.False(Unsafe.IsAddressLessThan(ref start,
+                    ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)));
+
+                Assert.False(Unsafe.IsAddressGreaterThan(ref start,
+                    ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches),
+                        BufferedStorage.CacheCount)));
+
+                lock (BufferedStorage.Locker)
+                {
+                    Release();
+                    Assert.True(Cache.IsNull);
+
+                    for (ref Cache cache = ref start; ; cache = ref Unsafe.Add(ref cache, 1))
+                    {
+                        // Wrap to the front of the list if we've reached the end.
+                        ref Cache end = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches),
+                            BufferedStorage.CacheCount);
+                        if (!Unsafe.IsAddressLessThan(ref cache, ref end))
+                        {
+                            cache = ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches);
+                        }
+
+                        // Break if we've iterated all the Caches
+                        if (!isFirst && Unsafe.AreSame(ref cache, ref StartCache.Value))
+                        {
+                            break;
+                        }
+
+                        if (cache.IsValid() && cache.Hits(offset, size) && cache.TryAcquireCache())
+                        {
+                            cache.Unlink();
+                            Cache = new Ref<Cache>(ref cache);
+                            return true;
+                        }
+
+                        isFirst = false;
+                    }
+
+                    Cache = default;
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Moves to the next dirty <see cref="Save.BufferedStorage.Cache"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if a dirty <see cref="Save.BufferedStorage.Cache"/> was found.
+            /// <see langword="false"/> if no dirty Caches exist,
+            /// or if all dirty Caches have already been iterated.</returns>
+            public bool AcquireNextDirtyCache()
+            {
+                Assert.NotNull(BufferedStorage);
+
+                ref Cache start = ref Cache.IsNull
+                    ? ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)
+                    : ref Unsafe.Add(ref Cache.Value, 1);
+
+                ref Cache end = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches),
+                    BufferedStorage.CacheCount);
+
+                // Validate the range.
+                Assert.False(Unsafe.IsAddressLessThan(ref start,
+                    ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)));
+
+                Assert.False(Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+                Release();
+                Assert.True(Cache.IsNull);
+
+                // Find the next dirty Cache
+                for (ref Cache cache = ref start;
+                    Unsafe.IsAddressLessThan(ref cache, ref end);
+                    cache = ref Unsafe.Add(ref cache, 1))
+                {
+                    if (cache.IsValid() && cache.IsDirty() && cache.TryAcquireCache())
+                    {
+                        cache.Unlink();
+                        Cache = new Ref<Cache>(ref cache);
+                        return true;
+                    }
+                }
+
+                Cache = default;
+                return false;
+            }
+
+            /// <summary>
+            /// Moves to the next valid <see cref="Save.BufferedStorage.Cache"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if a valid <see cref="Save.BufferedStorage.Cache"/> was found.
+            /// <see langword="false"/> if no valid Caches exist,
+            /// or if all valid Caches have already been iterated.</returns>
+            public bool AcquireNextValidCache()
+            {
+                Assert.NotNull(BufferedStorage);
+
+                ref Cache start = ref Cache.IsNull
+                    ? ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)
+                    : ref Unsafe.Add(ref Cache.Value, 1);
+
+                ref Cache end = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches),
+                    BufferedStorage.CacheCount);
+
+                // Validate the range.
+                Assert.False(Unsafe.IsAddressLessThan(ref start,
+                    ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)));
+
+                Assert.False(Unsafe.IsAddressGreaterThan(ref start, ref end));
+
+                Release();
+                Assert.True(Cache.IsNull);
+
+                // Find the next valid Cache
+                for (ref Cache cache = ref start;
+                    Unsafe.IsAddressLessThan(ref cache, ref end);
+                    cache = ref Unsafe.Add(ref cache, 1))
+                {
+                    if (cache.IsValid() && cache.TryAcquireCache())
+                    {
+                        cache.Unlink();
+                        Cache = new Ref<Cache>(ref cache);
+                        return true;
+                    }
+                }
+
+                Cache = default;
+                return false;
+            }
+
+            /// <summary>
+            /// Moves to a <see cref="Save.BufferedStorage.Cache"/> that can be used for
+            /// fetching a new block from the base <see cref="IStorage"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if a <see cref="Save.BufferedStorage.Cache"/> was acquired.
+            /// Otherwise, <see langword="false"/>.</returns>
+            public bool AcquireFetchableCache()
+            {
+                Assert.NotNull(BufferedStorage);
+
+                lock (BufferedStorage.Locker)
+                {
+                    Release();
+                    Assert.True(Cache.IsNull);
+
+                    Cache = new Ref<Cache>(ref BufferedStorage.NextFetchCache);
+
+                    if (!Cache.IsNull)
+                    {
+                        if (Cache.Value.IsValid())
+                            Cache.Value.TryAcquireCache();
+
+                        Cache.Value.Unlink();
+                    }
+
+                    return !Cache.IsNull;
+                }
+            }
+
+            /// <summary>
+            /// Reads from the current <see cref="Save.BufferedStorage.Cache"/>'s buffer.
+            /// The provided <paramref name="offset"/> must be inside the block of
+            /// data held by the <see cref="Save.BufferedStorage.Cache"/>.
+            /// </summary>
+            /// <param name="offset">The offset in the base <see cref="IStorage"/> to be read from.</param>
+            /// <param name="buffer">The buffer in which to place the read data.</param>
+            public void Read(long offset, Span<byte> buffer)
+            {
+                Assert.True(!Cache.IsNull);
+                Cache.Value.Read(offset, buffer);
+            }
+
+            /// <summary>
+            /// Buffers data to be written to the base <see cref="IStorage"/> when the current
+            /// <see cref="Save.BufferedStorage.Cache"/> is flushed. The provided <paramref name="offset"/>
+            /// must be contained by the block of data held by the <see cref="Save.BufferedStorage.Cache"/>.
+            /// </summary>
+            /// <param name="offset">The offset in the base <see cref="IStorage"/> to be written to.</param>
+            /// <param name="buffer">The buffer containing the data to be written.</param>
+            public void Write(long offset, ReadOnlySpan<byte> buffer)
+            {
+                Assert.True(!Cache.IsNull);
+                Cache.Value.Write(offset, buffer);
+            }
+
+            /// <summary>
+            /// If the current <see cref="Save.BufferedStorage.Cache"/> is dirty,
+            /// flushes its data to the base <see cref="IStorage"/>.
+            /// </summary>
+            /// <returns>The <see cref="Result"/> of the operation.</returns>
+            public Result Flush()
+            {
+                Assert.True(!Cache.IsNull);
+                return Cache.Value.Flush();
+            }
+
+            /// <summary>
+            /// Invalidates the data in the current <see cref="Save.BufferedStorage.Cache"/>.
+            /// Any dirty data will be discarded.
+            /// </summary>
+            public void Invalidate()
+            {
+                Assert.True(!Cache.IsNull);
+                Cache.Value.Invalidate();
+            }
+
+            /// <summary>
+            /// Checks if the current <see cref="Save.BufferedStorage.Cache"/> covers any of the specified range.
+            /// </summary>
+            /// <param name="offset">The start offset of the range to check.</param>
+            /// <param name="size">The size of the range to check.</param>
+            /// <returns><see langword="true"/> if the current <see cref="Save.BufferedStorage.Cache"/>'s range
+            /// covers any of the input range. Otherwise, <see langword="false"/>.</returns>
+            public bool Hits(long offset, long size)
+            {
+                Assert.True(!Cache.IsNull);
+                return Cache.Value.Hits(offset, size);
+            }
+
+            /// <summary>
+            /// Releases the current <see cref="Save.BufferedStorage.Cache"/> to return to the fetch list.
+            /// </summary>
+            private void Release()
+            {
+                if (!Cache.IsNull)
+                {
+                    // Make sure the Cache instance is in-range.
+                    Assert.False(Unsafe.IsAddressLessThan(ref Cache.Value,
+                        ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches)));
+
+                    Assert.False(Unsafe.IsAddressGreaterThan(ref Cache.Value,
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(BufferedStorage.Caches),
+                            BufferedStorage.CacheCount)));
+
+                    Cache.Value.Link();
+                    Cache = default;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides exclusive access to a <see cref="Save.BufferedStorage.Cache"/>
+        /// entry in a <see cref="Save.BufferedStorage"/>.
+        /// </summary>
+        private ref struct UniqueCache
+        {
+            // ReSharper disable once MemberHidesStaticFromOuterClass
+            private Ref<Cache> Cache { get; set; }
+            private BufferedStorage BufferedStorage { get; }
+
+            public UniqueCache(BufferedStorage bufferedStorage)
+            {
+                Assert.NotNull(bufferedStorage);
+                Cache = default;
+                BufferedStorage = bufferedStorage;
+            }
+
+            /// <summary>
+            /// Disposes the <see cref="UniqueCache"/>, releasing any held <see cref="Save.BufferedStorage.Cache"/>.
+            /// </summary>
+            public void Dispose()
+            {
+                if (!Cache.IsNull)
+                {
+                    lock (BufferedStorage.Locker)
+                    {
+                        Cache.Value.UnprepareFetch();
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Attempts to gain exclusive access to the <see cref="Save.BufferedStorage.Cache"/> held by
+            /// <paramref name="sharedCache"/> and prepare it to read a new block from the base <see cref="IStorage"/>.
+            /// </summary>
+            /// <param name="sharedCache">The <see cref="SharedCache"/> to gain exclusive access to.</param>
+            /// <returns>The <see cref="Result"/> of the operation, and <see langword="true"/> if exclusive
+            /// access to the <see cref="Cache"/> was gained; <see langword="false"/> if not.</returns>
+            public (Result Result, bool wasUpgradeSuccessful) Upgrade(in SharedCache sharedCache)
+            {
+                Assert.True(BufferedStorage == sharedCache.BufferedStorage);
+                Assert.True(!sharedCache.Cache.IsNull);
+
+                lock (BufferedStorage.Locker)
+                {
+                    (Result Result, bool wasUpgradeSuccessful) result = sharedCache.Cache.Value.PrepareFetch();
+
+                    if (result.Result.IsSuccess() && result.wasUpgradeSuccessful)
+                        Cache = sharedCache.Cache;
+
+                    return result;
+                }
+            }
+
+            /// <summary>
+            /// Reads the storage block containing the specified offset into the
+            /// <see cref="Save.BufferedStorage.Cache"/>'s buffer, and sets the Cache to that offset.
+            /// </summary>
+            /// <param name="offset">An offset in the block to fetch.</param>
+            /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+            /// <see cref="ResultFs.BufferAllocationFailed"/>: A buffer could not be allocated.</returns>
+            public Result Fetch(long offset)
+            {
+                Assert.True(!Cache.IsNull);
+
+                return Cache.Value.Fetch(offset);
+            }
+
+            /// <summary>
+            /// Fills the <see cref="Save.BufferedStorage.Cache"/>'s buffer from an input buffer containing a block of data
+            /// read from the base <see cref="IStorage"/>, and sets the Cache to that offset.
+            /// </summary>
+            /// <param name="offset">The start offset of the block in the base <see cref="IStorage"/>
+            /// that the data was read from.</param>
+            /// <param name="buffer">A buffer containing the data read from the base <see cref="IStorage"/>.</param>
+            /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+            /// <see cref="ResultFs.BufferAllocationFailed"/>: A buffer could not be allocated.</returns>
+            public Result FetchFromBuffer(long offset, ReadOnlySpan<byte> buffer)
+            {
+                Assert.True(!Cache.IsNull);
+
+                return Cache.Value.FetchFromBuffer(offset, buffer);
+            }
+        }
+
+        private SubStorage BaseStorage { get; set; }
+        private IBufferManager BufferManager { get; set; }
+        private long BlockSize { get; set; }
+
+        private long _baseStorageSize;
+        private long BaseStorageSize
+        {
+            get => _baseStorageSize;
+            set => _baseStorageSize = value;
+        }
+
+        private Cache[] Caches { get; set; }
+        private int CacheCount { get; set; }
+        private int NextAcquireCacheIndex { get; set; }
+        private int NextFetchCacheIndex { get; set; }
+        private object Locker { get; } = new();
+        private bool BulkReadEnabled { get; set; }
+
+        /// <summary>
+        /// The <see cref="Cache"/> at which new <see cref="SharedCache"/>s will begin iterating.
+        /// </summary>
+        private ref Cache NextAcquireCache => ref Caches[NextAcquireCacheIndex];
+
+        /// <summary>
+        /// A list of <see cref="Cache"/>s that can be used for fetching
+        /// new blocks of data from the base <see cref="IStorage"/>.
+        /// </summary>
+        private ref Cache NextFetchCache => ref Caches[NextFetchCacheIndex];
+
+        /// <summary>
+        /// Creates an uninitialized <see cref="BufferedStorage"/>.
+        /// </summary>
+        public BufferedStorage()
+        {
+            NextAcquireCacheIndex = InvalidIndex;
+            NextFetchCacheIndex = InvalidIndex;
+        }
+
+        /// <summary>
+        /// Disposes the <see cref="BufferedStorage"/>, flushing any cached data.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                FinalizeObject();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="BufferedStorage"/>.
+        /// Calling this method again afterwards will flush the current cache and
+        /// reinitialize the <see cref="BufferedStorage"/> with the new parameters.
+        /// </summary>
+        /// <param name="baseStorage">The base storage to use.</param>
+        /// <param name="bufferManager">The buffer manager used to allocate and cache memory.</param>
+        /// <param name="blockSize">The size of each cached block. Must be a power of 2.</param>
+        /// <param name="cacheCount">The maximum number of blocks that can be cached at one time.</param>
+        /// <returns></returns>
+        public Result Initialize(SubStorage baseStorage, IBufferManager bufferManager, int blockSize, int cacheCount)
+        {
+            Assert.NotNull(baseStorage);
+            Assert.NotNull(bufferManager);
+            Assert.True(blockSize > 0);
+            Assert.True(BitUtil.IsPowerOfTwo(blockSize));
+            Assert.True(cacheCount > 0);
+
+            // Get the base storage size.
+            Result rc = baseStorage.GetSize(out _baseStorageSize);
+            if (rc.IsFailure()) return rc;
+
+            // Set members.
+            BaseStorage = baseStorage;
+            BufferManager = bufferManager;
+            BlockSize = blockSize;
+            CacheCount = cacheCount;
+
+            // Allocate the caches.
+            if (Caches != null)
+            {
+                for (int i = 0; i < Caches.Length; i++)
+                {
+                    Caches[i].FinalizeObject();
+                }
+            }
+
+            Caches = new Cache[cacheCount];
+            if (Caches == null)
+            {
+                return ResultFs.AllocationFailureInBufferedStorageA.Log();
+            }
+
+            // Initialize the caches.
+            for (int i = 0; i < Caches.Length; i++)
+            {
+                Caches[i].Initialize(this, i);
+            }
+
+            NextAcquireCacheIndex = 0;
+            return Result.Success;
+        }
+
+        /// <summary>
+        /// Finalizes this <see cref="BufferedStorage"/>, flushing all buffers and leaving it in an uninitialized state.
+        /// </summary>
+        public void FinalizeObject()
+        {
+            BaseStorage = null;
+            BaseStorageSize = 0;
+
+            foreach (Cache cache in Caches)
+            {
+                cache.Dispose();
+            }
+
+            Caches = null;
+            CacheCount = 0;
+            NextFetchCacheIndex = InvalidIndex;
+        }
+
+        /// <summary>
+        /// Has this <see cref="BufferedStorage"/> been initialized?
+        /// </summary>
+        /// <returns><see langword="true"/> if this <see cref="BufferedStorage"/> is initialized.
+        /// Otherwise, <see langword="false"/>.</returns>
+        public bool IsInitialized() => Caches != null;
+
+        protected override Result DoRead(long offset, Span<byte> destination)
+        {
+            Assert.True(IsInitialized());
+
+            // Succeed if zero size.
+            if (destination.Length == 0)
+                return Result.Success;
+
+            // Do the read.
+            return ReadCore(offset, destination);
+        }
+
+        protected override Result DoWrite(long offset, ReadOnlySpan<byte> source)
+        {
+            Assert.True(IsInitialized());
+
+            // Succeed if zero size.
+            if (source.Length == 0)
+                return Result.Success;
+
+            // Do the read.
+            return WriteCore(offset, source);
+        }
+
+        protected override Result DoGetSize(out long size)
+        {
+            Assert.True(IsInitialized());
+
+            size = BaseStorageSize;
+            return Result.Success;
+        }
+
+        protected override Result DoSetSize(long size)
+        {
+            Assert.True(IsInitialized());
+
+            Result rc;
+            long prevSize = BaseStorageSize;
+            if (prevSize < size)
+            {
+                // Prepare to expand.
+                if (!Alignment.IsAlignedPow2(prevSize, (uint)BlockSize))
+                {
+                    using var cache = new SharedCache(this);
+                    long invalidateOffset = prevSize;
+                    long invalidateSize = size - prevSize;
+
+                    if (cache.AcquireNextOverlappedCache(invalidateOffset, invalidateSize))
+                    {
+                        rc = cache.Flush();
+                        if (rc.IsFailure()) return rc;
+
+                        cache.Invalidate();
+                    }
+
+                    Assert.True(!cache.AcquireNextOverlappedCache(invalidateOffset, invalidateSize));
+                }
+            }
+            else if (size < prevSize)
+            {
+                // Prepare to shrink.
+                using var cache = new SharedCache(this);
+                long invalidateOffset = prevSize;
+                long invalidateSize = size - prevSize;
+                bool isFragment = Alignment.IsAlignedPow2(size, (uint)BlockSize);
+
+                while (cache.AcquireNextOverlappedCache(invalidateOffset, invalidateSize))
+                {
+                    if (isFragment && cache.Hits(invalidateOffset, 1))
+                    {
+                        rc = cache.Flush();
+                        if (rc.IsFailure()) return rc;
+                    }
+
+                    cache.Invalidate();
+                }
+            }
+
+            // Set the size.
+            rc = BaseStorage.SetSize(size);
+            if (rc.IsFailure()) return rc;
+
+            // Get our new size.
+            rc = BaseStorage.GetSize(out long newSize);
+            if (rc.IsFailure()) return rc;
+
+            BaseStorageSize = newSize;
+            return Result.Success;
+        }
+
+        protected override Result DoOperateRange(Span<byte> outBuffer, OperationId operationId, long offset, long size,
+            ReadOnlySpan<byte> inBuffer)
+        {
+            Assert.True(IsInitialized());
+
+            // Invalidate caches if needed.
+            if (operationId == OperationId.InvalidateCache)
+            {
+                using var cache = new SharedCache(this);
+
+                while (cache.AcquireNextOverlappedCache(offset, size))
+                    cache.Invalidate();
+            }
+
+            return BaseStorage.OperateRange(outBuffer, operationId, offset, size, inBuffer);
+        }
+
+        protected override Result DoFlush()
+        {
+            Assert.True(IsInitialized());
+
+            // Flush caches.
+            using var cache = new SharedCache(this);
+            while (cache.AcquireNextDirtyCache())
+            {
+                Result flushResult = cache.Flush();
+                if (flushResult.IsFailure()) return flushResult;
+            }
+
+            // Flush the base storage.
+            return BaseStorage.Flush();
+        }
+
+        /// <summary>
+        /// Invalidates all cached data. Any unflushed data will be discarded.
+        /// </summary>
+        public void InvalidateCaches()
+        {
+            Assert.True(IsInitialized());
+
+            using var cache = new SharedCache(this);
+            while (cache.AcquireNextValidCache())
+                cache.Invalidate();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IBufferManager"/> used by this <see cref="BufferedStorage"/>.
+        /// </summary>
+        /// <returns>The buffer manager.</returns>
+        public IBufferManager GetBufferManager() => BufferManager;
+
+        public void EnableBulkRead() => BulkReadEnabled = true;
+
+        /// <summary>
+        /// Flushes the cache to the base <see cref="IStorage"/> if less than 1/8 of the
+        /// <see cref="IBufferManager"/>'s space can be used for allocation.
+        /// </summary>
+        /// <returns>The <see cref="Result"/> of the operation.</returns>
+        private Result PrepareAllocation()
+        {
+            uint flushThreshold = (uint)BufferManager.GetTotalSize() / 8;
+
+            if (BufferManager.GetTotalAllocatableSize() < flushThreshold)
+            {
+                Result rc = Flush();
+                if (rc.IsFailure()) return rc;
+            }
+
+            return Result.Success;
+        }
+
+        /// <summary>
+        /// Flushes all dirty caches if less than 25% of the space
+        /// in the <see cref="IBufferManager"/> is allocatable.
+        /// </summary>
+        /// <returns></returns>
+        private Result ControlDirtiness()
+        {
+            uint flushThreshold = (uint)BufferManager.GetTotalSize() / 4;
+
+            if (BufferManager.GetTotalAllocatableSize() < flushThreshold)
+            {
+                using var cache = new SharedCache(this);
+                int dirtyCount = 0;
+
+                while (cache.AcquireNextDirtyCache())
+                {
+                    if (++dirtyCount > 1)
+                    {
+                        Result rc = cache.Flush();
+                        if (rc.IsFailure()) return rc;
+
+                        cache.Invalidate();
+                    }
+                }
+            }
+
+            return Result.Success;
+        }
+
+        /// <summary>
+        /// Reads data from the base <see cref="IStorage"/> into the destination buffer.
+        /// </summary>
+        /// <param name="offset">The offset in the <see cref="IStorage"/> at which to begin reading.</param>
+        /// <param name="destination">The buffer where the read bytes will be stored.
+        /// The number of bytes read will be equal to the length of the buffer.</param>
+        /// <returns>The <see cref="Result"/> of the operation.</returns>
+        private Result ReadCore(long offset, Span<byte> destination)
+        {
+            Assert.NotNull(Caches);
+
+            // Validate the offset.
+            long baseStorageSize = BaseStorageSize;
+            if (offset < 0 || offset > baseStorageSize)
+                return ResultFs.InvalidOffset.Log();
+
+            // Setup tracking variables.
+            long remainingSize = Math.Min(destination.Length, baseStorageSize - offset);
+            long currentOffset = offset;
+            long bufferOffset = 0;
+
+            // Try doing a bulk read if enabled.
+            //
+            // The behavior of which blocks are cached should be the same between bulk reads and non-bulk reads.
+            // If the head and tail offsets of the range to be read are not aligned to block boundaries, those 
+            // head and/or tail partial blocks will end up in the cache if doing a non-bulk read.
+            //
+            // This is imitated during bulk reads by tracking if there are any partial head or tail blocks that aren't
+            // already in the cache. After the bulk read is complete these partial blocks will be added to the cache.
+            if (BulkReadEnabled)
+            {
+                // Read any blocks at the head of the range that are cached.
+                bool headCacheNeeded =
+                    ReadHeadCache(ref currentOffset, destination, ref remainingSize, ref bufferOffset);
+                if (remainingSize == 0) return Result.Success;
+
+                // Read any blocks at the tail of the range that are cached.
+                bool tailCacheNeeded = ReadTailCache(currentOffset, destination, ref remainingSize, bufferOffset);
+                if (remainingSize == 0) return Result.Success;
+
+                // Perform bulk reads.
+                const long bulkReadSizeMax = 1024 * 1024 * 2; // 2 MB
+
+                if (remainingSize < bulkReadSizeMax)
+                {
+                    // Try to do a bulk read.
+                    Result rc = BulkRead(currentOffset, destination.Slice((int)bufferOffset, (int)remainingSize),
+                        headCacheNeeded, tailCacheNeeded);
+
+                    // If the read fails due to insufficient pooled buffer size,
+                    // then we want to fall back to the normal read path.
+                    if (!ResultFs.AllocationFailurePooledBufferNotEnoughSize.Includes(rc))
+                        return rc;
+                }
+            }
+
+            // Repeatedly read until we're done.
+            while (remainingSize > 0)
+            {
+                // Determine how much to read this iteration.
+                int currentSize;
+
+                // If the offset is in the middle of a block. Read the remaining part of that block.
+                if (!Alignment.IsAlignedPow2(currentOffset, (uint)BlockSize))
+                {
+                    long alignedSize = BlockSize - (currentOffset & (BlockSize - 1));
+                    currentSize = (int)Math.Min(alignedSize, remainingSize);
+                }
+                // If we only have a partial block left to read, read that partial block.
+                else if (remainingSize < BlockSize)
+                {
+                    currentSize = (int)remainingSize;
+                }
+                // We have at least one full block to read. Read all the remaining full blocks at once.
+                else
+                {
+                    currentSize = (int)Alignment.AlignDownPow2(remainingSize, (uint)BlockSize);
+                }
+
+                Span<byte> currentDestination = destination.Slice((int)bufferOffset, currentSize);
+
+                // If reading a single block or less, read it using the cache
+                if (currentSize <= BlockSize)
+                {
+                    using var cache = new SharedCache(this);
+
+                    // Get the cache for our current block
+                    if (!cache.AcquireNextOverlappedCache(currentOffset, currentSize))
+                    {
+                        // The block wasn't in the cache. Read the block from the base storage
+                        Result rc = PrepareAllocation();
+                        if (rc.IsFailure()) return rc;
+
+                        // Loop until we can get exclusive access to the cache block
+                        while (true)
+                        {
+                            if (!cache.AcquireFetchableCache())
+                                return ResultFs.OutOfResource.Log();
+
+                            // Try to upgrade out SharedCache to a UniqueCache
+                            using var fetchCache = new UniqueCache(this);
+                            (Result Result, bool wasUpgradeSuccessful) upgradeResult = fetchCache.Upgrade(in cache);
+                            if (upgradeResult.Result.IsFailure())
+                                return upgradeResult.Result;
+
+                            // Fetch the data from the base storage into the cache buffer if successful
+                            if (upgradeResult.wasUpgradeSuccessful)
+                            {
+                                rc = fetchCache.Fetch(currentOffset);
+                                if (rc.IsFailure()) return rc;
+
+                                break;
+                            }
+                        }
+
+                        rc = ControlDirtiness();
+                        if (rc.IsFailure()) return rc;
+                    }
+
+                    // Copy the data from the cache buffer to the destination buffer
+                    cache.Read(currentOffset, currentDestination);
+                }
+                // If reading multiple blocks, flush the cache entries for all those blocks and
+                // read directly from the base storage into the destination buffer in a single read.
+                else
+                {
+                    // Flush all the cache blocks in the storage range being read
+                    using (var cache = new SharedCache(this))
+                    {
+                        while (cache.AcquireNextOverlappedCache(currentOffset, currentSize))
+                        {
+                            Result rc = cache.Flush();
+                            if (rc.IsFailure()) return rc;
+
+                            cache.Invalidate();
+                        }
+                    }
+
+                    // Read directly from the base storage to the destination buffer
+                    Result rcRead = BaseStorage.Read(currentOffset, currentDestination);
+                    if (rcRead.IsFailure()) return rcRead;
+                }
+
+                remainingSize -= currentSize;
+                currentOffset += currentSize;
+                bufferOffset += currentSize;
+            }
+
+            return Result.Success;
+        }
+
+        /// <summary>
+        /// Reads as much data into the beginning of the buffer that can be found in the cache. Returns
+        /// <see langword="true"/> if the next uncached data to read from the base <see cref="IStorage"/>
+        /// is not aligned to the beginning of a block.
+        /// </summary>
+        /// <param name="offset">The storage offset at which to begin reading. When this function returns, contains
+        /// the new offset at which to begin reading if any data was read by this function.</param>
+        /// <param name="buffer">The buffer to read data into.</param>
+        /// <param name="size">The size of the data to read. When this function returns, contains the new size
+        /// if any data was read by this function.</param>
+        /// <param name="bufferOffset">The offset of the buffer to begin writing data to. When this function returns,
+        /// contains the new offset to write data to if any data was read by this function.</param>
+        /// <returns><see langword="true"/> if the remaining data to read contains a partial block at the start.
+        /// Otherwise, <see langword="false"/>.</returns>
+        private bool ReadHeadCache(ref long offset, Span<byte> buffer, ref long size, ref long bufferOffset)
+        {
+            bool isCacheNeeded = !Alignment.IsAlignedPow2(offset, (uint)BlockSize);
+
+            while (size > 0)
+            {
+                long currentSize;
+
+                if (!Alignment.IsAlignedPow2(offset, (uint)BlockSize))
+                {
+                    long alignedSize = Alignment.AlignUpPow2(offset, (uint)BlockSize) - offset;
+                    currentSize = Math.Min(alignedSize, size);
+                }
+                else if (size < BlockSize)
+                {
+                    currentSize = size;
+                }
+                else
+                {
+                    currentSize = BlockSize;
+                }
+
+                using var cache = new SharedCache(this);
+
+                if (!cache.AcquireNextOverlappedCache(offset, currentSize))
+                    break;
+
+                cache.Read(offset, buffer.Slice((int)bufferOffset, (int)currentSize));
+                offset += currentSize;
+                bufferOffset += currentSize;
+                size -= currentSize;
+                isCacheNeeded = false;
+            }
+
+            return isCacheNeeded;
+        }
+
+        private bool ReadTailCache(long offset, Span<byte> buffer, ref long size, long bufferOffset)
+        {
+            bool isCacheNeeded = !Alignment.IsAlignedPow2(offset + size, (uint)BlockSize);
+
+            while (size > 0)
+            {
+                long currentOffsetEnd = offset + size;
+                long currentSize;
+
+                if (!Alignment.IsAlignedPow2(currentOffsetEnd, (uint)BlockSize))
+                {
+                    long alignedSize = currentOffsetEnd - Alignment.AlignDownPow2(currentOffsetEnd, (uint)BlockSize);
+                    currentSize = Math.Min(alignedSize, size);
+                }
+                else if (size < BlockSize)
+                {
+                    currentSize = size;
+                }
+                else
+                {
+                    currentSize = BlockSize;
+                }
+
+                long currentOffset = currentOffsetEnd - currentSize;
+                Assert.True(currentOffset >= 0);
+
+                using var cache = new SharedCache(this);
+
+                if (!cache.AcquireNextOverlappedCache(currentOffset, currentSize))
+                    break;
+
+                int currentBufferOffset = (int)(bufferOffset + currentOffset - offset);
+                cache.Read(currentOffset, buffer.Slice(currentBufferOffset, (int)currentSize));
+                size -= currentSize;
+                isCacheNeeded = false;
+            }
+
+            return isCacheNeeded;
+        }
+
+        /// <summary>
+        /// Reads directly from the base <see cref="IStorage"/> to the destination
+        /// <paramref name="buffer"/> using a single read.
+        /// </summary>
+        /// <param name="offset">The offset at which to begin reading</param>
+        /// <param name="buffer">The buffer where the read bytes will be stored.
+        /// The number of bytes read will be equal to the length of the buffer.</param>
+        /// <param name="isHeadCacheNeeded">Should the head block of the read data be cached?</param>
+        /// <param name="isTailCacheNeeded">Should the tail block of the read data be cached?</param>
+        /// <returns>The <see cref="Result"/> of the operation.</returns>
+        private Result BulkRead(long offset, Span<byte> buffer, bool isHeadCacheNeeded, bool isTailCacheNeeded)
+        {
+            Result rc;
+
+            // Determine aligned extents.
+            long alignedOffset = Alignment.AlignDownPow2(offset, (uint)BlockSize);
+            long alignedOffsetEnd = Math.Min(Alignment.AlignUpPow2(offset + buffer.Length, (uint)BlockSize),
+                BaseStorageSize);
+            long alignedSize = alignedOffsetEnd - alignedOffset;
+
+            // Allocate a work buffer if either the head or tail of the range isn't aligned.
+            // Otherwise directly use the output buffer.
+            Span<byte> workBuffer;
+            using var pooledBuffer = new PooledBuffer();
+
+            if (offset == alignedOffset && buffer.Length == alignedSize)
+            {
+                workBuffer = buffer;
+            }
+            else
+            {
+                pooledBuffer.AllocateParticularlyLarge((int)alignedSize, 1);
+                if (pooledBuffer.GetSize() < alignedSize)
+                    return ResultFs.AllocationFailurePooledBufferNotEnoughSize.Log();
+
+                workBuffer = pooledBuffer.GetBuffer();
+            }
+
+            // Ensure cache is coherent.
+            using (var cache = new SharedCache(this))
+            {
+                while (cache.AcquireNextOverlappedCache(alignedOffset, alignedSize))
+                {
+                    rc = cache.Flush();
+                    if (rc.IsFailure()) return rc;
+
+                    cache.Invalidate();
+                }
+            }
+
+            // Read from the base storage.
+            rc = BaseStorage.Read(alignedOffset, workBuffer.Slice(0, (int)alignedSize));
+            if (rc.IsFailure()) return rc;
+            if (workBuffer != buffer)
+            {
+                workBuffer.Slice((int)(offset - alignedOffset), buffer.Length).CopyTo(buffer);
+            }
+
+            bool cached = false;
+
+            // Cache the head block if needed.
+            if (isHeadCacheNeeded)
+            {
+                rc = PrepareAllocation();
+                if (rc.IsFailure()) return rc;
+
+                using var cache = new SharedCache(this);
+                while (true)
+                {
+                    if (!cache.AcquireFetchableCache())
+                        return ResultFs.OutOfResource.Log();
+
+                    using var fetchCache = new UniqueCache(this);
+                    (Result Result, bool wasUpgradeSuccessful) upgradeResult = fetchCache.Upgrade(in cache);
+                    if (upgradeResult.Result.IsFailure())
+                        return upgradeResult.Result;
+
+                    if (upgradeResult.wasUpgradeSuccessful)
+                    {
+                        rc = fetchCache.FetchFromBuffer(alignedOffset, workBuffer.Slice(0, (int)alignedSize));
+                        if (rc.IsFailure()) return rc;
+                        break;
+                    }
+                }
+
+                cached = true;
+            }
+
+            // Cache the tail block if needed.
+            if (isTailCacheNeeded && (!isHeadCacheNeeded || alignedSize > BlockSize))
+            {
+                if (!cached)
+                {
+                    rc = PrepareAllocation();
+                    if (rc.IsFailure()) return rc;
+                }
+
+                using var cache = new SharedCache(this);
+                while (true)
+                {
+                    if (!cache.AcquireFetchableCache())
+                        return ResultFs.OutOfResource.Log();
+
+                    using var fetchCache = new UniqueCache(this);
+                    (Result Result, bool wasUpgradeSuccessful) upgradeResult = fetchCache.Upgrade(in cache);
+                    if (upgradeResult.Result.IsFailure())
+                        return upgradeResult.Result;
+
+                    if (upgradeResult.wasUpgradeSuccessful)
+                    {
+                        long tailCacheOffset = Alignment.AlignDownPow2(offset + buffer.Length, (uint)BlockSize);
+                        long tailCacheSize = alignedSize - tailCacheOffset + alignedOffset;
+
+                        rc = fetchCache.FetchFromBuffer(tailCacheOffset,
+                            workBuffer.Slice((int)(tailCacheOffset - alignedOffset), (int)tailCacheSize));
+                        if (rc.IsFailure()) return rc;
+                        break;
+                    }
+                }
+            }
+
+            if (cached)
+            {
+                rc = ControlDirtiness();
+                if (rc.IsFailure()) return rc;
+            }
+
+            return Result.Success;
+        }
+
+        private Result WriteCore(long offset, ReadOnlySpan<byte> source)
+        {
+            Assert.NotNull(Caches);
+
+            // Validate the offset.
+            long baseStorageSize = BaseStorageSize;
+
+            if (offset < 0 || baseStorageSize < offset)
+                return ResultFs.InvalidOffset.Log();
+
+            // Setup tracking variables.
+            int remainingSize = (int)Math.Min(source.Length, baseStorageSize - offset);
+            long currentOffset = offset;
+            int bufferOffset = 0;
+
+            // Repeatedly read until we're done.
+            while (remainingSize > 0)
+            {
+                // Determine how much to read this iteration.
+                ReadOnlySpan<byte> currentSource = source.Slice(bufferOffset);
+                int currentSize;
+
+                if (!Alignment.IsAlignedPow2(currentOffset, (uint)BlockSize))
+                {
+                    int alignedSize = (int)(BlockSize - (currentOffset & (BlockSize - 1)));
+                    currentSize = Math.Min(alignedSize, remainingSize);
+                }
+                else if (remainingSize < BlockSize)
+                {
+                    currentSize = remainingSize;
+                }
+                else
+                {
+                    currentSize = Alignment.AlignDownPow2(remainingSize, (uint)BlockSize);
+                }
+
+                Result rc;
+                if (currentSize < BlockSize)
+                {
+                    using var cache = new SharedCache(this);
+
+                    if (!cache.AcquireNextOverlappedCache(currentOffset, currentSize))
+                    {
+                        rc = PrepareAllocation();
+                        if (rc.IsFailure()) return rc;
+
+                        while (true)
+                        {
+                            if (!cache.AcquireFetchableCache())
+                                return ResultFs.OutOfResource.Log();
+
+                            using var fetchCache = new UniqueCache(this);
+                            (Result Result, bool wasUpgradeSuccessful) upgradeResult = fetchCache.Upgrade(in cache);
+                            if (upgradeResult.Result.IsFailure())
+                                return upgradeResult.Result;
+
+                            if (upgradeResult.wasUpgradeSuccessful)
+                            {
+                                rc = fetchCache.Fetch(currentOffset);
+                                if (rc.IsFailure()) return rc;
+                                break;
+                            }
+                        }
+                    }
+                    cache.Write(currentOffset, currentSource.Slice(0, currentSize));
+
+                    BufferManagerUtility.EnableBlockingBufferManagerAllocation();
+
+                    rc = ControlDirtiness();
+                    if (rc.IsFailure()) return rc;
+                }
+                else
+                {
+                    using (var cache = new SharedCache(this))
+                    {
+                        while (cache.AcquireNextOverlappedCache(currentOffset, currentSize))
+                        {
+                            rc = cache.Flush();
+                            if (rc.IsFailure()) return rc;
+
+                            cache.Invalidate();
+                        }
+                    }
+
+                    rc = BaseStorage.Write(currentOffset, currentSource.Slice(0, currentSize));
+                    if (rc.IsFailure()) return rc;
+
+                    BufferManagerUtility.EnableBlockingBufferManagerAllocation();
+                }
+
+                remainingSize -= currentSize;
+                currentOffset += currentSize;
+                bufferOffset += currentSize;
+            }
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/LibHac/FsSystem/Save/JournalMap.cs
+++ b/src/LibHac/FsSystem/Save/JournalMap.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem.Save
 {
@@ -64,8 +65,8 @@ namespace LibHac.FsSystem.Save
             int physicalBlockCount = virtualBlockCount + Header.JournalBlockCount;
 
             int blockMapLength = virtualBlockCount * MapEntryLength;
-            int physicalBitmapLength = Utilities.AlignUp(physicalBlockCount, 32) / 8;
-            int virtualBitmapLength = Utilities.AlignUp(virtualBlockCount, 32) / 8;
+            int physicalBitmapLength = Alignment.AlignUp(physicalBlockCount, 32) / 8;
+            int virtualBitmapLength = Alignment.AlignUp(virtualBlockCount, 32) / 8;
 
             MapStorage.Slice(blockMapLength).Fill(SaveDataFileSystem.TrimFillValue);
             FreeBlocks.Slice(physicalBitmapLength).Fill(SaveDataFileSystem.TrimFillValue);

--- a/src/LibHac/FsSystem/Save/SaveDataFileSystemCore.cs
+++ b/src/LibHac/FsSystem/Save/SaveDataFileSystemCore.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Util;
 
 namespace LibHac.FsSystem.Save
 {
@@ -57,7 +58,7 @@ namespace LibHac.FsSystem.Save
                 return Result.Success;
             }
 
-            int blockCount = (int)Utilities.DivideByRoundUp(size, AllocationTable.Header.BlockSize);
+            int blockCount = (int)BitUtil.DivideUp(size, AllocationTable.Header.BlockSize);
             int startBlock = AllocationTable.Allocate(blockCount);
 
             if (startBlock == -1)

--- a/src/LibHac/FsSystem/SectorStorage.cs
+++ b/src/LibHac/FsSystem/SectorStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using LibHac.Fs;
+using LibHac.Util;
 
 namespace LibHac.FsSystem
 {
@@ -20,7 +21,7 @@ namespace LibHac.FsSystem
 
             baseStorage.GetSize(out long baseSize).ThrowIfFailure();
 
-            SectorCount = (int)Utilities.DivideByRoundUp(baseSize, SectorSize);
+            SectorCount = (int)BitUtil.DivideUp(baseSize, SectorSize);
             Length = baseSize;
 
             LeaveOpen = leaveOpen;
@@ -57,7 +58,7 @@ namespace LibHac.FsSystem
             rc = BaseStorage.GetSize(out long newSize);
             if (rc.IsFailure()) return rc;
 
-            SectorCount = (int)Utilities.DivideByRoundUp(newSize, SectorSize);
+            SectorCount = (int)BitUtil.DivideUp(newSize, SectorSize);
             Length = newSize;
 
             return Result.Success;

--- a/src/LibHac/FsSystem/UniqueLockSemaphore.cs
+++ b/src/LibHac/FsSystem/UniqueLockSemaphore.cs
@@ -80,7 +80,7 @@ namespace LibHac.FsSystem
             Shared.Move(out _semaphore, ref semaphore);
             Shared.Move(out _pinnedObject, ref pinnedObject);
 
-            Assert.AssertTrue(_semaphore.IsLocked);
+            Assert.True(_semaphore.IsLocked);
         }
 
         public void Dispose()

--- a/src/LibHac/Kernel/InitialProcessBinaryReader.cs
+++ b/src/LibHac/Kernel/InitialProcessBinaryReader.cs
@@ -64,7 +64,7 @@ namespace LibHac.Kernel
         private static Result GetKipOffsets(out (int offset, int size)[] kipOffsets, IStorage iniStorage,
             int processCount)
         {
-            Assert.AssertTrue(processCount <= MaxProcessCount);
+            Assert.True(processCount <= MaxProcessCount);
 
             kipOffsets = default;
 

--- a/src/LibHac/Kvdb/FlatMapKeyValueStore.cs
+++ b/src/LibHac/Kvdb/FlatMapKeyValueStore.cs
@@ -486,7 +486,7 @@ namespace LibHac.Kvdb
                 if (_count > 0)
                 {
                     // The key being added must be greater than the last key in the list.
-                    Assert.AssertTrue(key.CompareTo(_entries[_count - 1].Key) > 0);
+                    Assert.True(key.CompareTo(_entries[_count - 1].Key) > 0);
                 }
 
                 _entries[_count] = new KeyValue(in key, value);

--- a/src/LibHac/Kvdb/KeyValueArchive.cs
+++ b/src/LibHac/Kvdb/KeyValueArchive.cs
@@ -75,7 +75,7 @@ namespace LibHac.Kvdb
             Unsafe.SkipInit(out count);
 
             // This should only be called at the start of reading stream.
-            Assert.AssertTrue(_offset == 0);
+            Assert.True(_offset == 0);
 
             // Read and validate header.
             var header = new KeyValueArchiveHeader();
@@ -177,7 +177,7 @@ namespace LibHac.Kvdb
         private void Write(ReadOnlySpan<byte> source)
         {
             // Bounds check.
-            Assert.AssertTrue(_offset + source.Length <= _buffer.Length &&
+            Assert.True(_offset + source.Length <= _buffer.Length &&
                               _offset + source.Length > _offset);
 
             source.CopyTo(_buffer.Slice(_offset));

--- a/src/LibHac/Ticket.cs
+++ b/src/LibHac/Ticket.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using LibHac.Common.Keys;
+using LibHac.Util;
 
 namespace LibHac
 {
@@ -112,7 +113,7 @@ namespace LibHac
                     throw new ArgumentOutOfRangeException();
             }
 
-            long bodyStart = Utilities.GetNextMultiple(4 + sigLength, 0x40);
+            long bodyStart = Alignment.AlignUp(4 + sigLength, 0x40);
 
             writer.Write((int)SignatureType);
 

--- a/src/LibHac/Util/Alignment.cs
+++ b/src/LibHac/Util/Alignment.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using LibHac.Diag;
+
+namespace LibHac.Util
+{
+    public static class Alignment
+    {
+        // The alignment functions in this class come from C++ templates that always cast to unsigned types
+
+        public static ulong AlignUpPow2(ulong value, uint alignment)
+        {
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+
+            ulong invMask = alignment - 1;
+            return ((value + invMask) & ~invMask);
+        }
+
+        public static ulong AlignDownPow2(ulong value, uint alignment)
+        {
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+
+            ulong invMask = alignment - 1;
+            return (value & ~invMask);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool IsAlignedPow2(ulong value, uint alignment)
+        {
+            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+
+            ulong invMask = alignment - 1;
+            return (value & invMask) == 0;
+        }
+
+        public static bool IsAlignedPow2<T>(Span<T> buffer, uint alignment)
+        {
+            return IsAlignedPow2(buffer, alignment);
+        }
+
+        public static bool IsAlignedPow2<T>(ReadOnlySpan<T> buffer, uint alignment)
+        {
+            return IsAlignedPow2(ref MemoryMarshal.GetReference(buffer), alignment);
+        }
+
+        public static unsafe bool IsAlignedPow2<T>(ref T pointer, uint alignment)
+        {
+            return IsAlignedPow2((ulong)Unsafe.AsPointer(ref pointer), alignment);
+        }
+
+        public static int AlignUpPow2(int value, uint alignment) => (int)AlignUpPow2((ulong)value, alignment);
+        public static long AlignUpPow2(long value, uint alignment) => (long)AlignUpPow2((ulong)value, alignment);
+        public static int AlignDownPow2(int value, uint alignment) => (int)AlignDownPow2((ulong)value, alignment);
+        public static long AlignDownPow2(long value, uint alignment) => (long)AlignDownPow2((ulong)value, alignment);
+        public static bool IsAlignedPow2(int value, uint alignment) => IsAlignedPow2((ulong)value, alignment);
+        public static bool IsAlignedPow2(long value, uint alignment) => IsAlignedPow2((ulong)value, alignment);
+
+        public static ulong AlignUp(ulong value, uint alignment) => AlignDown(value + alignment - 1, alignment);
+        public static ulong AlignDown(ulong value, uint alignment) => value - value % alignment;
+        public static bool IsAligned(ulong value, uint alignment) => value % alignment == 0;
+
+        public static int AlignUp(int value, uint alignment) => (int)AlignUp((ulong)value, alignment);
+        public static long AlignUp(long value, uint alignment) => (long)AlignUp((ulong)value, alignment);
+        public static int AlignDown(int value, uint alignment) => (int)AlignDown((ulong)value, alignment);
+        public static long AlignDown(long value, uint alignment) => (long)AlignDown((ulong)value, alignment);
+        public static bool IsAligned(int value, uint alignment) => IsAligned((ulong)value, alignment);
+        public static bool IsAligned(long value, uint alignment) => IsAligned((ulong)value, alignment);
+    }
+}

--- a/src/LibHac/Util/Alignment.cs
+++ b/src/LibHac/Util/Alignment.cs
@@ -11,7 +11,7 @@ namespace LibHac.Util
 
         public static ulong AlignUpPow2(ulong value, uint alignment)
         {
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+            Assert.True(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return ((value + invMask) & ~invMask);
@@ -19,7 +19,7 @@ namespace LibHac.Util
 
         public static ulong AlignDownPow2(ulong value, uint alignment)
         {
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+            Assert.True(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return (value & ~invMask);
@@ -28,7 +28,7 @@ namespace LibHac.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static bool IsAlignedPow2(ulong value, uint alignment)
         {
-            Assert.AssertTrue(BitUtil.IsPowerOfTwo(alignment));
+            Assert.True(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return (value & invMask) == 0;

--- a/src/LibHac/Util/Alignment.cs
+++ b/src/LibHac/Util/Alignment.cs
@@ -25,18 +25,12 @@ namespace LibHac.Util
             return (value & ~invMask);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static bool IsAlignedPow2(ulong value, uint alignment)
         {
             Assert.True(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return (value & invMask) == 0;
-        }
-
-        public static bool IsAlignedPow2<T>(Span<T> buffer, uint alignment)
-        {
-            return IsAlignedPow2(buffer, alignment);
         }
 
         public static bool IsAlignedPow2<T>(ReadOnlySpan<T> buffer, uint alignment)

--- a/src/LibHac/Util/BitUtil.cs
+++ b/src/LibHac/Util/BitUtil.cs
@@ -1,0 +1,46 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace LibHac.Util
+{
+    public static class BitUtil
+    {
+        public static bool IsPowerOfTwo(int value)
+        {
+            return value > 0 && ResetLeastSignificantOneBit(value) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPowerOfTwo(long value)
+        {
+            return value > 0 && ResetLeastSignificantOneBit(value) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPowerOfTwo(ulong value)
+        {
+            return value > 0 && ResetLeastSignificantOneBit(value) == 0;
+        }
+
+        private static int ResetLeastSignificantOneBit(int value)
+        {
+            return value & (value - 1);
+        }
+
+        private static long ResetLeastSignificantOneBit(long value)
+        {
+            return value & (value - 1);
+        }
+
+        private static ulong ResetLeastSignificantOneBit(ulong value)
+        {
+            return value & (value - 1);
+        }
+
+        // DivideUp comes from a C++ template that always casts to unsigned types
+        public static uint DivideUp(uint value, uint divisor) => (value + divisor - 1) / divisor;
+        public static ulong DivideUp(ulong value, ulong divisor) => (value + divisor - 1) / divisor;
+
+        public static int DivideUp(int value, int divisor) => (int)DivideUp((uint)value, (uint)divisor);
+        public static long DivideUp(long value, long divisor) => (long)DivideUp((ulong)value, (ulong)divisor);
+    }
+}

--- a/src/LibHac/Util/Optional.cs
+++ b/src/LibHac/Util/Optional.cs
@@ -14,7 +14,7 @@ namespace LibHac.Util
         {
             get
             {
-                Assert.AssertTrue(_hasValue);
+                Assert.True(_hasValue);
                 // It's beautiful
                 return ref MemoryMarshal.CreateSpan(ref _value, 1)[0];
             }
@@ -23,7 +23,7 @@ namespace LibHac.Util
         {
             get
             {
-                Assert.AssertTrue(_hasValue);
+                Assert.True(_hasValue);
                 return ref SpanHelpers.CreateReadOnlySpan(in _value, 1)[0];
             }
         }

--- a/src/LibHac/Utilities.cs
+++ b/src/LibHac/Utilities.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -10,35 +9,6 @@ namespace LibHac
     public static class Utilities
     {
         private const int MediaSize = 0x200;
-
-        public static byte[][] CreateJaggedByteArray(int len1, int len2)
-        {
-            var array = new byte[len1][];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                array[i] = new byte[len2];
-            }
-
-            return array;
-        }
-
-        public static byte[][][] CreateJaggedByteArray(int len1, int len2, int len3)
-        {
-            var array = new byte[len1][][];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                array[i] = new byte[len2][];
-
-                for (int j = 0; j < array[i].Length; j++)
-                {
-                    array[i][j] = new byte[len3];
-                }
-            }
-
-            return array;
-        }
 
         public static bool ArraysEqual<T>(T[] a1, T[] a2)
         {
@@ -265,26 +235,7 @@ namespace LibHac
             // Return formatted number with suffix
             return readable.ToString("0.### ") + suffix;
         }
-
-        public static long GetNextMultiple(long value, int multiple)
-        {
-            if (multiple <= 0)
-                return value;
-
-            if (value % multiple == 0)
-                return value;
-
-            return value + multiple - value % multiple;
-        }
-
-        public static int DivideByRoundUp(int value, int divisor) => (value + divisor - 1) / divisor;
-        public static long DivideByRoundUp(long value, long divisor) => (value + divisor - 1) / divisor;
-
-        public static int AlignUp(int value, int multiple) => AlignDown(value + multiple - 1, multiple);
-        public static long AlignUp(long value, long multiple) => AlignDown(value + multiple - 1, multiple);
-        public static int AlignDown(int value, int multiple) => value - value % multiple;
-        public static long AlignDown(long value, long multiple) => value - value % multiple;
-
+        
         public static void IncrementByteArray(byte[] array)
         {
             for (int i = array.Length - 1; i >= 0; i--)
@@ -341,100 +292,11 @@ namespace LibHac
             _ => "Unknown"
         };
 
-        public static bool IsSubRange(long startIndex, long subLength, long length)
-        {
-            bool isOutOfRange = startIndex < 0 || startIndex > length || subLength < 0 || startIndex > length - subLength;
-            return !isOutOfRange;
-        }
-
         public static int GetMasterKeyRevision(int keyGeneration)
         {
             if (keyGeneration == 0) return 0;
 
             return keyGeneration - 1;
-        }
-
-        public static bool IsPowerOfTwo(int value)
-        {
-            return value > 0 && ResetLeastSignificantOneBit(value) == 0;
-        }
-
-        public static bool IsPowerOfTwo(long value)
-        {
-            return value > 0 && ResetLeastSignificantOneBit(value) == 0;
-        }
-
-        public static BigInteger GetBigInteger(this ReadOnlySpan<byte> bytes)
-        {
-            var signPadded = new byte[bytes.Length + 1];
-            bytes.CopyTo(signPadded.AsSpan(1));
-            Array.Reverse(signPadded);
-            return new BigInteger(signPadded);
-        }
-
-        public static byte[] GetBytes(this BigInteger value, int size)
-        {
-            byte[] bytes = value.ToByteArray();
-
-            if (size == -1)
-            {
-                size = bytes.Length;
-            }
-
-            if (bytes.Length > size + 1)
-            {
-                throw new InvalidOperationException($"Cannot squeeze value {value} to {size} bytes from {bytes.Length}.");
-            }
-
-            if (bytes.Length == size + 1 && bytes[bytes.Length - 1] != 0)
-            {
-                throw new InvalidOperationException($"Cannot squeeze value {value} to {size} bytes from {bytes.Length}.");
-            }
-
-            Array.Resize(ref bytes, size);
-            Array.Reverse(bytes);
-            return bytes;
-        }
-
-        public static BigInteger ModInverse(BigInteger e, BigInteger n)
-        {
-            BigInteger r = n;
-            BigInteger newR = e;
-            BigInteger t = 0;
-            BigInteger newT = 1;
-
-            while (newR != 0)
-            {
-                BigInteger quotient = r / newR;
-                BigInteger temp;
-
-                temp = t;
-                t = newT;
-                newT = temp - quotient * newT;
-
-                temp = r;
-                r = newR;
-                newR = temp - quotient * newR;
-            }
-
-            if (t < 0)
-            {
-                t = t + n;
-            }
-
-            return t;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int ResetLeastSignificantOneBit(int value)
-        {
-            return value & (value - 1);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static long ResetLeastSignificantOneBit(long value)
-        {
-            return value & (value - 1);
         }
     }
 }

--- a/tests/LibHac.Tests/Fs/StorageTester.cs
+++ b/tests/LibHac.Tests/Fs/StorageTester.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using LibHac.Fs;
+
+namespace LibHac.Tests.Fs
+{
+    public class StorageTester
+    {
+        private Random _random;
+        private byte[][] _backingArrays;
+        private byte[][] _buffers;
+        private int _size;
+
+        private int[] _frequentAccessOffsets;
+        private int _lastAccessEnd;
+        private int _totalAccessCount;
+        private Configuration _config;
+
+        public class Configuration
+        {
+            public Entry[] Entries { get; set; }
+            public int[] SizeClassProbs { get; set; }
+            public int[] SizeClassMaxSizes { get; set; }
+            public int[] TaskProbs { get; set; }
+            public int[] AccessTypeProbs { get; set; }
+            public ulong RngSeed { get; set; }
+            public int FrequentAccessBlockCount { get; set; }
+        }
+
+        public StorageTester(Configuration config)
+        {
+            Entry[] entries = config.Entries;
+
+            if (entries.Length < 2)
+            {
+                throw new ArgumentException("At least 2 storage entries must be provided", nameof(config.Entries));
+            }
+
+            if (entries.Select(x => x.BackingArray.Length).Distinct().Count() != 1)
+            {
+                throw new ArgumentException("All storages must have the same size.", nameof(config.Entries));
+            }
+
+            if (entries[0].BackingArray.Length == 0)
+            {
+                throw new ArgumentException("The storage size must be greater than 0.", nameof(config.Entries));
+            }
+
+            _config = config;
+            _random = new Random(config.RngSeed);
+
+            _backingArrays = entries.Select(x => x.BackingArray).ToArray();
+
+            _buffers = new byte[entries.Length][];
+            for (int i = 0; i < entries.Length; i++)
+            {
+                _buffers[i] = new byte[config.SizeClassMaxSizes[^1]];
+            }
+
+            _size = entries[0].BackingArray.Length;
+            _lastAccessEnd = 0;
+
+            _frequentAccessOffsets = new int[config.FrequentAccessBlockCount];
+            for (int i = 0; i < _frequentAccessOffsets.Length; i++)
+            {
+                _frequentAccessOffsets[i] = ChooseOffset(AccessType.Random);
+            }
+        }
+
+        //public StorageTester(ulong rngSeed, int frequentAccessBlockCount, params Entry[] entries)
+        //{
+        //    if (entries.Length < 2)
+        //    {
+        //        throw new ArgumentException("At least 2 storage entries must be provided", nameof(entries));
+        //    }
+
+        //    if (entries.Select(x => x.BackingArray.Length).Distinct().Count() != 1)
+        //    {
+        //        throw new ArgumentException("All storages must have the same size.", nameof(entries));
+        //    }
+
+        //    if (entries[0].BackingArray.Length == 0)
+        //    {
+        //        throw new ArgumentException("The storage size must be greater than 0.", nameof(entries));
+        //    }
+
+        //    _random = new Random(rngSeed);
+
+        //    _entries = entries;
+        //    _backingArrays = entries.Select(x => x.BackingArray).ToArray();
+
+        //    _buffers = new byte[entries.Length][];
+        //    for (int i = 0; i < entries.Length; i++)
+        //    {
+        //        _buffers[i] = new byte[SizeClassMaxSizes[^1]];
+        //    }
+
+        //    _size = _entries[0].BackingArray.Length;
+        //    _lastAccessEnd = 0;
+
+        //    _frequentAccessOffsets = new int[frequentAccessBlockCount];
+        //    for (int i = 0; i < _frequentAccessOffsets.Length; i++)
+        //    {
+        //        _frequentAccessOffsets[i] = ChooseOffset(AccessType.Random);
+        //    }
+        //}
+
+        public void Run(long accessCount)
+        {
+            long endCount = _totalAccessCount + accessCount;
+
+            while (_totalAccessCount < endCount)
+            {
+                Task task = ChooseTask();
+                switch (task)
+                {
+                    case Task.Read:
+                        RunRead();
+                        break;
+                    case Task.Write:
+                        RunWrite();
+                        break;
+                    case Task.Flush:
+                        RunFlush();
+                        break;
+                }
+
+                _totalAccessCount++;
+            }
+        }
+
+        private void RunRead()
+        {
+            int sizeClass = ChooseSizeClass();
+            AccessType accessType = ChooseAccessType();
+            int offset = ChooseOffset(accessType);
+            int size = ChooseSize(offset, sizeClass);
+
+            for (int i = 0; i < _config.Entries.Length; i++)
+            {
+                Entry entry = _config.Entries[i];
+                entry.Storage.Read(offset, _buffers[i].AsSpan(0, size)).ThrowIfFailure();
+            }
+
+            if (!CompareBuffers(_buffers, size))
+            {
+                throw new InvalidDataException($"Read: Offset {offset}; Size {size}");
+            }
+        }
+
+        private void RunWrite()
+        {
+            int sizeClass = ChooseSizeClass();
+            AccessType accessType = ChooseAccessType();
+            int offset = ChooseOffset(accessType);
+            int size = ChooseSize(offset, sizeClass);
+
+            Span<byte> buffer = _buffers[0].AsSpan(0, size);
+            _random.NextBytes(buffer);
+
+            for (int i = 0; i < _config.Entries.Length; i++)
+            {
+                Entry entry = _config.Entries[i];
+                entry.Storage.Write(offset, buffer).ThrowIfFailure();
+            }
+        }
+
+        private void RunFlush()
+        {
+            foreach (Entry entry in _config.Entries)
+            {
+                entry.Storage.Flush().ThrowIfFailure();
+            }
+
+            if (!CompareBuffers(_backingArrays, _size))
+            {
+                throw new InvalidDataException("Flush");
+            }
+        }
+
+        private Task ChooseTask() => (Task)ChooseProb(_config.TaskProbs);
+        private int ChooseSizeClass() => ChooseProb(_config.SizeClassProbs);
+        private AccessType ChooseAccessType() => (AccessType)ChooseProb(_config.AccessTypeProbs);
+
+        private int ChooseOffset(AccessType type) => type switch
+        {
+            AccessType.Random => _random.Next(0, _size),
+            AccessType.Sequential => _lastAccessEnd == _size ? 0 : _lastAccessEnd,
+            AccessType.FrequentBlock => _frequentAccessOffsets[_random.Next(0, _frequentAccessOffsets.Length)],
+            _ => 0
+        };
+
+        private int ChooseSize(int offset, int sizeClass)
+        {
+            int availableSize = Math.Max(0, _size - offset);
+            int randSize = _random.Next(0, _config.SizeClassMaxSizes[sizeClass]);
+            return Math.Min(availableSize, randSize);
+        }
+
+        private int ChooseProb(int[] weights)
+        {
+            int total = 0;
+            foreach (int weight in weights)
+            {
+                total += weight;
+            }
+
+            int rand = _random.Next(0, total);
+            int currentThreshold = 0;
+
+            for (int i = 0; i < weights.Length; i++)
+            {
+                currentThreshold += weights[i];
+
+                if (rand < currentThreshold)
+                    return i;
+            }
+
+            return 0;
+        }
+
+        private bool CompareBuffers(byte[][] buffers, int size)
+        {
+            Span<byte> baseBuffer = buffers[0].AsSpan(0, size);
+
+            for (int i = 1; i < buffers.Length; i++)
+            {
+                Span<byte> testBuffer = buffers[i].AsSpan(0, size);
+                if (!baseBuffer.SequenceEqual(testBuffer))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public readonly struct Entry
+        {
+            public readonly IStorage Storage;
+            public readonly byte[] BackingArray;
+
+            public Entry(IStorage storage, byte[] backingArray)
+            {
+                Storage = storage;
+                BackingArray = backingArray;
+            }
+        }
+
+        private enum Task
+        {
+            Read = 0,
+            Write = 1,
+            Flush = 2
+        }
+
+        private enum AccessType
+        {
+            Random = 0,
+            Sequential = 1,
+            FrequentBlock = 2
+        }
+    }
+}

--- a/tests/LibHac.Tests/FsSystem/BufferedStorageTests.cs
+++ b/tests/LibHac.Tests/FsSystem/BufferedStorageTests.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+using LibHac.Fs;
+using LibHac.FsSystem;
+using LibHac.FsSystem.Save;
+using LibHac.Tests.Fs;
+using Xunit;
+
+namespace LibHac.Tests.FsSystem
+{
+    public class BufferedStorageTests
+    {
+        [Fact]
+        public void Write_SingleBlock_CanReadBack()
+        {
+            byte[] buffer = new byte[0x18000];
+            byte[] workBuffer = new byte[0x18000];
+            var bufferManager = new FileSystemBufferManager();
+            Assert.Success(bufferManager.Initialize(5, buffer, 0x4000, workBuffer));
+
+            byte[] storageBuffer = new byte[0x80000];
+            var baseStorage = new SubStorage(new MemoryStorage(storageBuffer), 0, storageBuffer.Length);
+
+            var bufferedStorage = new BufferedStorage();
+            Assert.Success(bufferedStorage.Initialize(baseStorage, bufferManager, 0x4000, 4));
+
+            byte[] writeBuffer = new byte[0x400];
+            byte[] readBuffer = new byte[0x400];
+
+            writeBuffer.AsSpan().Fill(0xAA);
+            Assert.Success(bufferedStorage.Write(0x10000, writeBuffer));
+            Assert.Success(bufferedStorage.Read(0x10000, readBuffer));
+
+            Assert.Equal(writeBuffer, readBuffer);
+        }
+
+        public class AccessTestConfig
+        {
+            public int[] SizeClassProbs { get; set; }
+            public int[] SizeClassMaxSizes { get; set; }
+            public int[] TaskProbs { get; set; }
+            public int[] AccessTypeProbs { get; set; }
+            public ulong RngSeed { get; set; }
+            public int FrequentAccessBlockCount { get; set; }
+            public int BlockSize { get; set; }
+            public int StorageCacheCount { get; set; }
+            public bool EnableBulkRead { get; set; }
+            public int StorageSize { get; set; }
+            public int HeapSize { get; set; }
+            public int HeapBlockSize { get; set; }
+            public int BufferManagerCacheCount { get; set; }
+        }
+
+
+        public static AccessTestConfig[] AccessTestConfigs =
+        {
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 5},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 50, 1}, // Read, Write, Flush
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 35467,
+                FrequentAccessBlockCount = 6,
+                BlockSize = 0x4000,
+                StorageCacheCount = 40,
+                EnableBulkRead = true,
+                StorageSize = 0x1000000,
+                HeapSize = 0x180000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 50
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 5},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 50, 1}, // Read, Write, Flush
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 6548433,
+                FrequentAccessBlockCount = 6,
+                BlockSize = 0x4000,
+                StorageCacheCount = 40,
+                EnableBulkRead = false,
+                StorageSize = 0x1000000,
+                HeapSize = 0x180000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 50
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 0},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 0, 0},
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 756478,
+                FrequentAccessBlockCount = 16,
+                BlockSize = 0x4000,
+                StorageCacheCount = 8,
+                EnableBulkRead = true,
+                StorageSize = 0x1000000,
+                HeapSize = 0xE00000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 0x400
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 0},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 0, 0},
+                AccessTypeProbs = new[] {0, 0, 5}, // Random, Sequential, Frequent block
+                RngSeed = 38197549,
+                FrequentAccessBlockCount = 16,
+                BlockSize = 0x4000,
+                StorageCacheCount = 16,
+                EnableBulkRead = false,
+                StorageSize = 0x1000000,
+                HeapSize = 0xE00000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 0x400
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 0},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 50, 1}, // Read, Write, Flush
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 567365,
+                FrequentAccessBlockCount = 6,
+                BlockSize = 0x4000,
+                StorageCacheCount = 8,
+                EnableBulkRead = false,
+                StorageSize = 0x100000,
+                HeapSize = 0x180000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 50
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 0},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 50, 1}, // Read, Write, Flush
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 949365,
+                FrequentAccessBlockCount = 6,
+                BlockSize = 0x4000,
+                StorageCacheCount = 8,
+                EnableBulkRead = false,
+                StorageSize = 0x100000,
+                HeapSize = 0x180000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 50
+            },
+            new()
+            {
+                SizeClassProbs = new[] {50, 50, 10},
+                SizeClassMaxSizes = new[] {0x4000, 0x80000, 0x800000}, // 4 KB, 512 KB, 8 MB
+                TaskProbs = new[] {50, 50, 1}, // Read, Write, Flush
+                AccessTypeProbs = new[] {10, 10, 5}, // Random, Sequential, Frequent block
+                RngSeed = 670670,
+                FrequentAccessBlockCount = 16,
+                BlockSize = 0x4000,
+                StorageCacheCount = 8,
+                EnableBulkRead = true,
+                StorageSize = 0x1000000,
+                HeapSize = 0xE00000,
+                HeapBlockSize = 0x4000,
+                BufferManagerCacheCount = 0x400
+            }
+        };
+
+        private static TheoryData<T> CreateTheoryData<T>(IEnumerable<T> items)
+        {
+            var output = new TheoryData<T>();
+
+            foreach (T item in items)
+            {
+                output.Add(item);
+            }
+
+            return output;
+        }
+
+        public static TheoryData<AccessTestConfig> AccessTestTheoryData = CreateTheoryData(AccessTestConfigs);
+
+        [Theory]
+        [MemberData(nameof(AccessTestTheoryData))]
+        public void ReadWrite_AccessCorrectnessTestAgainstMemoryStorage(AccessTestConfig config)
+        {
+            int orderMax = FileSystemBuddyHeap.QueryOrderMax((nuint)config.HeapSize, (nuint)config.HeapBlockSize);
+            int workBufferSize = (int)FileSystemBuddyHeap.QueryWorkBufferSize(orderMax);
+            byte[] workBuffer = GC.AllocateArray<byte>(workBufferSize, true);
+            byte[] heapBuffer = new byte[config.HeapSize];
+
+            var bufferManager = new FileSystemBufferManager();
+            Assert.Success(bufferManager.Initialize(config.BufferManagerCacheCount, heapBuffer, config.HeapBlockSize, workBuffer));
+
+            byte[] memoryStorageArray = new byte[config.StorageSize];
+            byte[] bufferedStorageArray = new byte[config.StorageSize];
+
+            var memoryStorage = new MemoryStorage(memoryStorageArray);
+            var baseBufferedStorage = new SubStorage(new MemoryStorage(bufferedStorageArray), 0, bufferedStorageArray.Length);
+
+            var bufferedStorage = new BufferedStorage();
+            Assert.Success(bufferedStorage.Initialize(baseBufferedStorage, bufferManager, config.BlockSize, config.StorageCacheCount));
+
+            if (config.EnableBulkRead)
+            {
+                bufferedStorage.EnableBulkRead();
+            }
+
+            var memoryStorageEntry = new StorageTester.Entry(memoryStorage, memoryStorageArray);
+            var bufferedStorageEntry = new StorageTester.Entry(bufferedStorage, bufferedStorageArray);
+
+            var testerConfig = new StorageTester.Configuration()
+            {
+                Entries = new[] { memoryStorageEntry, bufferedStorageEntry },
+                SizeClassProbs = config.SizeClassProbs,
+                SizeClassMaxSizes = config.SizeClassMaxSizes,
+                TaskProbs = config.TaskProbs,
+                AccessTypeProbs = config.AccessTypeProbs,
+                RngSeed = config.RngSeed,
+                FrequentAccessBlockCount = config.FrequentAccessBlockCount
+            };
+
+            var tester = new StorageTester(testerConfig);
+            tester.Run(0x100);
+        }
+    }
+}

--- a/tests/LibHac.Tests/FsSystem/FileSystemBufferManagerTests.cs
+++ b/tests/LibHac.Tests/FsSystem/FileSystemBufferManagerTests.cs
@@ -1,0 +1,89 @@
+﻿using LibHac.Fs;
+using LibHac.FsSystem;
+using Xunit;
+
+namespace LibHac.Tests.FsSystem
+{
+    public class FileSystemBufferManagerTests
+    {
+        private FileSystemBufferManager CreateManager(int size, int blockSize = 0x4000, int maxCacheCount = 16)
+        {
+            int orderMax = FileSystemBuddyHeap.QueryOrderMax((nuint)size, (nuint)blockSize);
+            nuint workBufferSize = FileSystemBuddyHeap.QueryWorkBufferSize(orderMax);
+            byte[] workBuffer = new byte[workBufferSize];
+            byte[] heapBuffer = new byte[size];
+
+            var bufferManager = new FileSystemBufferManager();
+            Assert.Success(bufferManager.Initialize(maxCacheCount, heapBuffer, blockSize, workBuffer));
+            return bufferManager;
+        }
+
+        [Fact]
+        public void AllocateBuffer_NoFreeSpace_ReturnsNull()
+        {
+            FileSystemBufferManager manager = CreateManager(0x20000);
+            Buffer buffer1 = manager.AllocateBuffer(0x10000);
+            Buffer buffer2 = manager.AllocateBuffer(0x10000);
+            Buffer buffer3 = manager.AllocateBuffer(0x4000);
+
+            Assert.True(!buffer1.IsNull);
+            Assert.True(!buffer2.IsNull);
+            Assert.True(buffer3.IsNull);
+        }
+
+        [Fact]
+        public void AcquireCache_EntryNotEvicted_ReturnsEntry()
+        {
+            FileSystemBufferManager manager = CreateManager(0x20000);
+            Buffer buffer1 = manager.AllocateBuffer(0x10000);
+
+            long handle = manager.RegisterCache(buffer1, new IBufferManager.BufferAttribute());
+
+            manager.AllocateBuffer(0x10000);
+            Buffer buffer3 = manager.AcquireCache(handle);
+
+            Assert.Equal(buffer1, buffer3);
+        }
+
+        [Fact]
+        public void AcquireCache_EntryEvicted_ReturnsNull()
+        {
+            FileSystemBufferManager manager = CreateManager(0x20000);
+            Buffer buffer1 = manager.AllocateBuffer(0x10000);
+
+            long handle = manager.RegisterCache(buffer1, new IBufferManager.BufferAttribute());
+
+            manager.AllocateBuffer(0x20000);
+            Buffer buffer3 = manager.AcquireCache(handle);
+
+            Assert.True(buffer3.IsNull);
+        }
+
+        [Fact]
+        public void AcquireCache_MultipleEntriesEvicted_OldestAreEvicted()
+        {
+            FileSystemBufferManager manager = CreateManager(0x20000);
+            Buffer buffer1 = manager.AllocateBuffer(0x8000);
+            Buffer buffer2 = manager.AllocateBuffer(0x8000);
+            Buffer buffer3 = manager.AllocateBuffer(0x8000);
+            Buffer buffer4 = manager.AllocateBuffer(0x8000);
+
+            long handle1 = manager.RegisterCache(buffer1, new IBufferManager.BufferAttribute());
+            long handle2 = manager.RegisterCache(buffer2, new IBufferManager.BufferAttribute());
+            long handle3 = manager.RegisterCache(buffer3, new IBufferManager.BufferAttribute());
+            long handle4 = manager.RegisterCache(buffer4, new IBufferManager.BufferAttribute());
+
+            manager.AllocateBuffer(0x10000);
+
+            Buffer buffer1B = manager.AcquireCache(handle1);
+            Buffer buffer2B = manager.AcquireCache(handle2);
+            Buffer buffer3B = manager.AcquireCache(handle3);
+            Buffer buffer4B = manager.AcquireCache(handle4);
+
+            Assert.True(buffer1B.IsNull);
+            Assert.True(buffer2B.IsNull);
+            Assert.Equal(buffer3, buffer3B);
+            Assert.Equal(buffer4, buffer4B);
+        }
+    }
+}

--- a/tests/LibHac.Tests/LibHac.Tests.csproj
+++ b/tests/LibHac.Tests/LibHac.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/LibHac.Tests/Random.cs
+++ b/tests/LibHac.Tests/Random.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace LibHac.Tests
+{
+    public struct Random
+    {
+        private ulong _state1;
+        private ulong _state2;
+
+        public Random(ulong seed)
+        {
+            ulong x = seed;
+            ulong z = x + 0x9e3779b97f4a7c15;
+            z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+            z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+            x = z ^ (z >> 31);
+            z = (x += 0x9e3779b97f4a7c15);
+            z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+            z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+            _state1 = z ^ (z >> 31);
+            _state2 = x;
+        }
+
+        ulong Next()
+        {
+            ulong s0 = _state1;
+            ulong s1 = _state2;
+            ulong result = BitOperations.RotateLeft(s0 + s1, 17) + s0;
+
+            s1 ^= s0;
+            _state1 = BitOperations.RotateLeft(s0, 49) ^ s1 ^ (s1 << 21);
+            _state2 = BitOperations.RotateLeft(s1, 28);
+
+            return result;
+        }
+
+        public int Next(int minValue, int maxValue)
+        {
+            if (minValue > maxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minValue));
+            }
+
+            long range = (long)maxValue - minValue;
+            return (int)((uint)Next() * (1.0 / uint.MaxValue) * range) + minValue;
+        }
+
+        public void NextBytes(Span<byte> buffer)
+        {
+            Span<ulong> bufferUlong = MemoryMarshal.Cast<byte, ulong>(buffer);
+
+            for (int i = 0; i < bufferUlong.Length; i++)
+            {
+                bufferUlong[i] = Next();
+            }
+
+            for (int i = bufferUlong.Length * sizeof(ulong); i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)Next();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds:
- `LibHac.Fs.IBufferManager`
- `LibHac.FsSystem.FileSystemBuddyHeap`
- `LibHac.FsSystem.FileSystemBufferManager`
- `LibHac.FsSystem.PooledBuffer`
- `LibHac.FsSystem.Save.BufferedStorage`
- Some tests for `LibHac.FsSystem.Save.BufferedStorage`

Renames `LibHac.Diag.Assert.AssertTrue` to `LibHac.Diag.Assert.True`

Moves some methods out of `LibHac.Utilities` to `LibHac.Util.Alignment` and `LibHac.Util.BitUtil`