### PR TITLE
Update ReSharper var style and warnings

### DIFF
--- a/src/LibHac/Common/Keys/DefaultKeySet.cs
+++ b/src/LibHac/Common/Keys/DefaultKeySet.cs
@@ -90,19 +90,19 @@ namespace LibHac.Common.Keys
             // TSEC secrets aren't public yet, so the TSEC root keys will be treated as
             // root keys even though they're derived.
 
-            keys.Add(new KeyInfo(10, Type.DeviceRoot, "secure_boot_key", (set, i) => set.SecureBootKey));
-            keys.Add(new KeyInfo(11, Type.DeviceRoot, "tsec_key", (set, i) => set.TsecKey));
-            keys.Add(new KeyInfo(12, Type.DeviceDrvd, "device_key", (set, i) => set.DeviceKey));
+            keys.Add(new KeyInfo(10, Type.DeviceRoot, "secure_boot_key", (set, _) => set.SecureBootKey));
+            keys.Add(new KeyInfo(11, Type.DeviceRoot, "tsec_key", (set, _) => set.TsecKey));
+            keys.Add(new KeyInfo(12, Type.DeviceDrvd, "device_key", (set, _) => set.DeviceKey));
 
-            keys.Add(new KeyInfo(20, Type.CommonRoot, "tsec_root_kek", (set, i) => set.TsecRootKek));
-            keys.Add(new KeyInfo(21, Type.CommonRoot, "package1_mac_kek", (set, i) => set.Package1MacKek));
-            keys.Add(new KeyInfo(22, Type.CommonRoot, "package1_kek", (set, i) => set.Package1Kek));
+            keys.Add(new KeyInfo(20, Type.CommonRoot, "tsec_root_kek", (set, _) => set.TsecRootKek));
+            keys.Add(new KeyInfo(21, Type.CommonRoot, "package1_mac_kek", (set, _) => set.Package1MacKek));
+            keys.Add(new KeyInfo(22, Type.CommonRoot, "package1_kek", (set, _) => set.Package1Kek));
 
             keys.Add(new KeyInfo(30, Type.CommonRoot, "tsec_auth_signature", 0, 0x20, (set, i) => set.TsecAuthSignatures[i]));
 
             keys.Add(new KeyInfo(40, Type.CommonRoot, "tsec_root_key", 0, 0x20, (set, i) => set.TsecRootKeys[i]));
 
-            keys.Add(new KeyInfo(50, Type.CommonSeed, "keyblob_mac_key_source", (set, i) => set.KeyBlobMacKeySource));
+            keys.Add(new KeyInfo(50, Type.CommonSeed, "keyblob_mac_key_source", (set, _) => set.KeyBlobMacKeySource));
             keys.Add(new KeyInfo(51, Type.CommonSeed, "keyblob_key_source", 0, 6, (set, i) => set.KeyBlobKeySources[i]));
 
             keys.Add(new KeyInfo(55, Type.DeviceDrvd, "keyblob_key", 0, 6, (set, i) => set.KeyBlobKeys[i]));
@@ -115,61 +115,61 @@ namespace LibHac.Common.Keys
 
             keys.Add(new KeyInfo(90, Type.CommonSeed, "master_kek_source", 6, 0x20, (set, i) => set.MasterKekSources[i]));
 
-            keys.Add(new KeyInfo(100, Type.CommonRoot, "mariko_bek", (set, i) => set.MarikoBek));
-            keys.Add(new KeyInfo(101, Type.CommonRoot, "mariko_kek", (set, i) => set.MarikoKek));
+            keys.Add(new KeyInfo(100, Type.CommonRoot, "mariko_bek", (set, _) => set.MarikoBek));
+            keys.Add(new KeyInfo(101, Type.CommonRoot, "mariko_kek", (set, _) => set.MarikoKek));
 
             keys.Add(new KeyInfo(110, Type.CommonRoot, "mariko_aes_class_key", 0, 0xC, (set, i) => set.MarikoAesClassKeys[i]));
             keys.Add(new KeyInfo(120, Type.CommonSeedDiff, "mariko_master_kek_source", 0, 0x20, (set, i) => set.MarikoMasterKekSources[i]));
             keys.Add(new KeyInfo(130, Type.CommonDrvd, "master_kek", 0, 0x20, (set, i) => set.MasterKeks[i]));
-            keys.Add(new KeyInfo(140, Type.CommonSeed, "master_key_source", (set, i) => set.MasterKeySource));
+            keys.Add(new KeyInfo(140, Type.CommonSeed, "master_key_source", (set, _) => set.MasterKeySource));
             keys.Add(new KeyInfo(150, Type.CommonDrvd, "master_key", 0, 0x20, (set, i) => set.MasterKeys[i]));
 
             keys.Add(new KeyInfo(160, Type.CommonDrvd, "package1_key", 0, 0x20, (set, i) => set.Package1Keys[i]));
             keys.Add(new KeyInfo(170, Type.CommonDrvd, "package1_mac_key", 6, 0x20, (set, i) => set.Package1MacKeys[i]));
-            keys.Add(new KeyInfo(180, Type.CommonSeed, "package2_key_source", (set, i) => set.Package2KeySource));
+            keys.Add(new KeyInfo(180, Type.CommonSeed, "package2_key_source", (set, _) => set.Package2KeySource));
             keys.Add(new KeyInfo(190, Type.CommonDrvd, "package2_key", 0, 0x20, (set, i) => set.Package2Keys[i]));
 
-            keys.Add(new KeyInfo(200, Type.CommonSeed, "bis_kek_source", (set, i) => set.BisKekSource));
+            keys.Add(new KeyInfo(200, Type.CommonSeed, "bis_kek_source", (set, _) => set.BisKekSource));
             keys.Add(new KeyInfo(201, Type.CommonSeed, "bis_key_source", 0, 4, (set, i) => set.BisKeySources[i]));
 
             keys.Add(new KeyInfo(205, Type.DeviceDrvd, "bis_key", 0, 4, (set, i) => set.BisKeys[i]));
 
-            keys.Add(new KeyInfo(210, Type.CommonSeed, "per_console_key_source", (set, i) => set.PerConsoleKeySource));
-            keys.Add(new KeyInfo(211, Type.CommonSeed, "retail_specific_aes_key_source", (set, i) => set.RetailSpecificAesKeySource));
-            keys.Add(new KeyInfo(212, Type.CommonSeed, "aes_kek_generation_source", (set, i) => set.AesKekGenerationSource));
-            keys.Add(new KeyInfo(213, Type.CommonSeed, "aes_key_generation_source", (set, i) => set.AesKeyGenerationSource));
-            keys.Add(new KeyInfo(214, Type.CommonSeed, "titlekek_source", (set, i) => set.TitleKekSource));
+            keys.Add(new KeyInfo(210, Type.CommonSeed, "per_console_key_source", (set, _) => set.PerConsoleKeySource));
+            keys.Add(new KeyInfo(211, Type.CommonSeed, "retail_specific_aes_key_source", (set, _) => set.RetailSpecificAesKeySource));
+            keys.Add(new KeyInfo(212, Type.CommonSeed, "aes_kek_generation_source", (set, _) => set.AesKekGenerationSource));
+            keys.Add(new KeyInfo(213, Type.CommonSeed, "aes_key_generation_source", (set, _) => set.AesKeyGenerationSource));
+            keys.Add(new KeyInfo(214, Type.CommonSeed, "titlekek_source", (set, _) => set.TitleKekSource));
 
             keys.Add(new KeyInfo(220, Type.CommonDrvd, "titlekek", 0, 0x20, (set, i) => set.TitleKeks[i]));
 
-            keys.Add(new KeyInfo(230, Type.CommonSeed, "header_kek_source", (set, i) => set.HeaderKekSource));
-            keys.Add(new KeyInfo(231, Type.CommonSeed, "header_key_source", (set, i) => set.HeaderKeySource));
-            keys.Add(new KeyInfo(232, Type.CommonDrvd, "header_key", (set, i) => set.HeaderKey));
+            keys.Add(new KeyInfo(230, Type.CommonSeed, "header_kek_source", (set, _) => set.HeaderKekSource));
+            keys.Add(new KeyInfo(231, Type.CommonSeed, "header_key_source", (set, _) => set.HeaderKeySource));
+            keys.Add(new KeyInfo(232, Type.CommonDrvd, "header_key", (set, _) => set.HeaderKey));
 
-            keys.Add(new KeyInfo(240, Type.CommonSeed, "key_area_key_application_source", (set, i) => set.KeyAreaKeyApplicationSource));
-            keys.Add(new KeyInfo(241, Type.CommonSeed, "key_area_key_ocean_source", (set, i) => set.KeyAreaKeyOceanSource));
-            keys.Add(new KeyInfo(242, Type.CommonSeed, "key_area_key_system_source", (set, i) => set.KeyAreaKeySystemSource));
+            keys.Add(new KeyInfo(240, Type.CommonSeed, "key_area_key_application_source", (set, _) => set.KeyAreaKeyApplicationSource));
+            keys.Add(new KeyInfo(241, Type.CommonSeed, "key_area_key_ocean_source", (set, _) => set.KeyAreaKeyOceanSource));
+            keys.Add(new KeyInfo(242, Type.CommonSeed, "key_area_key_system_source", (set, _) => set.KeyAreaKeySystemSource));
 
-            keys.Add(new KeyInfo(250, Type.CommonSeed, "save_mac_kek_source", (set, i) => set.DeviceUniqueSaveMacKekSource));
+            keys.Add(new KeyInfo(250, Type.CommonSeed, "save_mac_kek_source", (set, _) => set.DeviceUniqueSaveMacKekSource));
             keys.Add(new KeyInfo(251, Type.CommonSeed, "save_mac_key_source", 0, 2, (set, i) => set.DeviceUniqueSaveMacKeySources[i]));
             keys.Add(new KeyInfo(252, Type.DeviceDrvd, "save_mac_key", 0, 2, (set, i) => set.DeviceUniqueSaveMacKeys[i]));
-            keys.Add(new KeyInfo(-01, Type.CommonSeed, "save_mac_key_source", (set, i) => set.DeviceUniqueSaveMacKeySources[0]));
+            keys.Add(new KeyInfo(-01, Type.CommonSeed, "save_mac_key_source", (set, _) => set.DeviceUniqueSaveMacKeySources[0]));
 
-            keys.Add(new KeyInfo(253, Type.CommonSeed, "save_mac_sd_card_kek_source", (set, i) => set.SeedUniqueSaveMacKekSource));
-            keys.Add(new KeyInfo(254, Type.CommonSeed, "save_mac_sd_card_key_source", (set, i) => set.SeedUniqueSaveMacKeySource));
-            keys.Add(new KeyInfo(255, Type.DeviceDrvd, "save_mac_sd_card_key", (set, i) => set.SeedUniqueSaveMacKey));
+            keys.Add(new KeyInfo(253, Type.CommonSeed, "save_mac_sd_card_kek_source", (set, _) => set.SeedUniqueSaveMacKekSource));
+            keys.Add(new KeyInfo(254, Type.CommonSeed, "save_mac_sd_card_key_source", (set, _) => set.SeedUniqueSaveMacKeySource));
+            keys.Add(new KeyInfo(255, Type.DeviceDrvd, "save_mac_sd_card_key", (set, _) => set.SeedUniqueSaveMacKey));
 
-            keys.Add(new KeyInfo(260, Type.DeviceRoot, "sd_seed", (set, i) => set.SdCardEncryptionSeed));
+            keys.Add(new KeyInfo(260, Type.DeviceRoot, "sd_seed", (set, _) => set.SdCardEncryptionSeed));
 
-            keys.Add(new KeyInfo(261, Type.CommonSeed, "sd_card_kek_source", (set, i) => set.SdCardKekSource));
-            keys.Add(new KeyInfo(262, Type.CommonSeed, "sd_card_save_key_source", (set, i) => set.SdCardKeySources[0]));
-            keys.Add(new KeyInfo(263, Type.CommonSeed, "sd_card_nca_key_source", (set, i) => set.SdCardKeySources[1]));
-            keys.Add(new KeyInfo(264, Type.CommonSeed, "sd_card_custom_storage_key_source", (set, i) => set.SdCardKeySources[2]));
+            keys.Add(new KeyInfo(261, Type.CommonSeed, "sd_card_kek_source", (set, _) => set.SdCardKekSource));
+            keys.Add(new KeyInfo(262, Type.CommonSeed, "sd_card_save_key_source", (set, _) => set.SdCardKeySources[0]));
+            keys.Add(new KeyInfo(263, Type.CommonSeed, "sd_card_nca_key_source", (set, _) => set.SdCardKeySources[1]));
+            keys.Add(new KeyInfo(264, Type.CommonSeed, "sd_card_custom_storage_key_source", (set, _) => set.SdCardKeySources[2]));
 
-            keys.Add(new KeyInfo(270, Type.CommonSeedDiff, "xci_header_key", (set, i) => set.XciHeaderKey));
+            keys.Add(new KeyInfo(270, Type.CommonSeedDiff, "xci_header_key", (set, _) => set.XciHeaderKey));
 
-            keys.Add(new KeyInfo(280, Type.CommonRoot, "eticket_rsa_kek", (set, i) => set.ETicketRsaKek));
-            keys.Add(new KeyInfo(281, Type.CommonRoot, "ssl_rsa_kek", (set, i) => set.SslRsaKek));
+            keys.Add(new KeyInfo(280, Type.CommonRoot, "eticket_rsa_kek", (set, _) => set.ETicketRsaKek));
+            keys.Add(new KeyInfo(281, Type.CommonRoot, "ssl_rsa_kek", (set, _) => set.SslRsaKek));
 
             keys.Add(new KeyInfo(290, Type.CommonDrvd, "key_area_key_application", 0, 0x20, (set, i) => set.KeyAreaKeys[i][0]));
             keys.Add(new KeyInfo(300, Type.CommonDrvd, "key_area_key_ocean", 0, 0x20, (set, i) => set.KeyAreaKeys[i][1]));

--- a/src/LibHac/Common/U8Span.cs
+++ b/src/LibHac/Common/U8Span.cs
@@ -80,7 +80,7 @@ namespace LibHac.Common
             int length = StringUtils.GetLength(_buffer);
 
             // Allocate an extra byte for the null terminator
-            var buffer = new byte[length + 1];
+            byte[] buffer = new byte[length + 1];
             _buffer.Slice(0, length).CopyTo(buffer);
 
             return new U8String(buffer);

--- a/src/LibHac/Crypto/Rsa.cs
+++ b/src/LibHac/Crypto/Rsa.cs
@@ -182,7 +182,7 @@ namespace LibHac.Crypto
 
         private static BigInteger GetBigInteger(this ReadOnlySpan<byte> bytes)
         {
-            var signPadded = new byte[bytes.Length + 1];
+            byte[] signPadded = new byte[bytes.Length + 1];
             bytes.CopyTo(signPadded.AsSpan(1));
             Array.Reverse(signPadded);
             return new BigInteger(signPadded);

--- a/src/LibHac/CryptoOld.cs
+++ b/src/LibHac/CryptoOld.cs
@@ -12,8 +12,8 @@ namespace LibHac
     {
         public static void GenerateKek(byte[] key, byte[] src, byte[] dest, byte[] kekSeed, byte[] keySeed)
         {
-            var kek = new byte[Aes.KeySize128];
-            var srcKek = new byte[Aes.KeySize128];
+            byte[] kek = new byte[Aes.KeySize128];
+            byte[] srcKek = new byte[Aes.KeySize128];
 
             Aes.DecryptEcb128(kekSeed, kek, key);
             Aes.DecryptEcb128(src, srcKek, kek);
@@ -30,16 +30,16 @@ namespace LibHac
 
         public static RSAParameters DecryptRsaKey(byte[] encryptedKey, byte[] kek)
         {
-            var counter = new byte[0x10];
+            byte[] counter = new byte[0x10];
             Array.Copy(encryptedKey, counter, 0x10);
-            var key = new byte[0x230];
+            byte[] key = new byte[0x230];
             Array.Copy(encryptedKey, 0x10, key, 0, 0x230);
 
             new Aes128CtrTransform(kek, counter).TransformBlock(key);
 
-            var d = new byte[0x100];
-            var n = new byte[0x100];
-            var e = new byte[4];
+            byte[] d = new byte[0x100];
+            byte[] n = new byte[0x100];
+            byte[] e = new byte[4];
             Array.Copy(key, 0, d, 0, 0x100);
             Array.Copy(key, 0x100, n, 0, 0x100);
             Array.Copy(key, 0x200, e, 0, 4);
@@ -54,7 +54,7 @@ namespace LibHac
             var rsa = new RSACryptoServiceProvider();
             rsa.ImportParameters(keyParams);
 
-            var test = new byte[] { 12, 34, 56, 78 };
+            byte[] test = { 12, 34, 56, 78 };
             byte[] testEnc = rsa.Encrypt(test, false);
             byte[] testDec = rsa.Decrypt(testEnc, false);
 

--- a/src/LibHac/Fs/PathTool.cs
+++ b/src/LibHac/Fs/PathTool.cs
@@ -154,7 +154,7 @@ namespace LibHac.Fs
 
             if (ContainsParentDirectoryAlt(path2))
             {
-                var buffer2 = new byte[PathTools.MaxPathLength + 1];
+                byte[] buffer2 = new byte[PathTools.MaxPathLength + 1];
 
                 buffer2[0] = StringTraits.DirectorySeparator;
                 int j;

--- a/src/LibHac/FsSrv/Impl/DeepRetryFileSystem.cs
+++ b/src/LibHac/FsSrv/Impl/DeepRetryFileSystem.cs
@@ -7,6 +7,7 @@ namespace LibHac.FsSrv.Impl
 {
     public class DeepRetryFileSystem : ForwardingFileSystem
     {
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
         private ReferenceCountedDisposable<DeepRetryFileSystem>.WeakReference SelfReference { get; set; }
         private ReferenceCountedDisposable<IRomFileSystemAccessFailureManager> AccessFailureManager { get; set; }
 

--- a/src/LibHac/FsSrv/PathNormalizer.cs
+++ b/src/LibHac/FsSrv/PathNormalizer.cs
@@ -43,7 +43,7 @@ namespace LibHac.FsSrv
             }
             else
             {
-                var buffer = new byte[PathTools.MaxPathLength + 1];
+                byte[] buffer = new byte[PathTools.MaxPathLength + 1];
 
                 rc = PathTool.Normalize(buffer, out long normalizedLength, path, preserveUnc, hasMountName);
                 if (rc.IsFailure()) return rc;

--- a/src/LibHac/FsSystem/Aes128CtrStorage.cs
+++ b/src/LibHac/FsSystem/Aes128CtrStorage.cs
@@ -47,7 +47,7 @@ namespace LibHac.FsSystem
             if (key == null) throw new NullReferenceException(nameof(key));
             if (key.Length != BlockSize) throw new ArgumentException(nameof(key), $"Key must be {BlockSize} bytes long");
 
-            var initialCounter = new byte[BlockSize];
+            byte[] initialCounter = new byte[BlockSize];
             if (counterHi != null)
             {
                 Array.Copy(counterHi, initialCounter, 8);
@@ -114,7 +114,7 @@ namespace LibHac.FsSystem
 
         public static byte[] CreateCounter(ulong hiBytes, long offset)
         {
-            var counter = new byte[0x10];
+            byte[] counter = new byte[0x10];
 
             BinaryPrimitives.WriteUInt64BigEndian(counter, hiBytes);
             BinaryPrimitives.WriteInt64BigEndian(counter.AsSpan(8), offset / 0x10);

--- a/src/LibHac/FsSystem/AesXtsFile.cs
+++ b/src/LibHac/FsSystem/AesXtsFile.cs
@@ -52,7 +52,7 @@ namespace LibHac.FsSystem
 
         public byte[] GetKey()
         {
-            var key = new byte[0x20];
+            byte[] key = new byte[0x20];
             Array.Copy(Header.DecryptedKey1, 0, key, 0, 0x10);
             Array.Copy(Header.DecryptedKey2, 0, key, 0x10, 0x10);
 

--- a/src/LibHac/FsSystem/AesXtsFileHeader.cs
+++ b/src/LibHac/FsSystem/AesXtsFileHeader.cs
@@ -116,7 +116,7 @@ namespace LibHac.FsSystem
             byte[] key1 = writeDecryptedKey ? DecryptedKey1 : EncryptedKey1;
             byte[] key2 = writeDecryptedKey ? DecryptedKey2 : EncryptedKey2;
 
-            var data = new byte[0x80];
+            byte[] data = new byte[0x80];
 
             Array.Copy(Signature, data, 0x20);
             MemoryMarshal.Write(data.AsSpan(0x20), ref magic);

--- a/src/LibHac/FsSystem/Buffers/FileSystemBuddyHeap.cs
+++ b/src/LibHac/FsSystem/Buffers/FileSystemBuddyHeap.cs
@@ -35,6 +35,7 @@ namespace LibHac.FsSystem
             public bool IsEmpty() => EntryCount == 0;
             public int GetSize() => EntryCount;
 
+            // ReSharper disable once UnusedMember.Local
             public PageEntry* GetFront() => FirstPageEntry;
 
             public PageEntry* PopFront()

--- a/src/LibHac/FsSystem/FileReader.cs
+++ b/src/LibHac/FsSystem/FileReader.cs
@@ -122,7 +122,7 @@ namespace LibHac.FsSystem
 
         public byte[] ReadBytes(long offset, int length, bool updatePosition)
         {
-            var bytes = new byte[length];
+            byte[] bytes = new byte[length];
             _file.Read(out long _, offset, bytes).ThrowIfFailure();
 
             if (updatePosition) Position = offset + length;
@@ -138,7 +138,7 @@ namespace LibHac.FsSystem
 
         public string ReadAscii(long offset, int length, bool updatePosition)
         {
-            var bytes = new byte[length];
+            byte[] bytes = new byte[length];
             _file.Read(out long _, offset, bytes).ThrowIfFailure();
 
             if (updatePosition) Position = offset + length;

--- a/src/LibHac/FsSystem/HierarchicalIntegrityVerificationStorage.cs
+++ b/src/LibHac/FsSystem/HierarchicalIntegrityVerificationStorage.cs
@@ -148,7 +148,7 @@ namespace LibHac.FsSystem
             long blockSize = storage.SectorSize;
             int blockCount = (int)BitUtil.DivideUp(Length, blockSize);
 
-            var buffer = new byte[blockSize];
+            byte[] buffer = new byte[blockSize];
             var result = Validity.Valid;
 
             logger?.SetTotal(blockCount);

--- a/src/LibHac/FsSystem/IntegrityVerificationStorage.cs
+++ b/src/LibHac/FsSystem/IntegrityVerificationStorage.cs
@@ -175,7 +175,7 @@ namespace LibHac.FsSystem
 
                 _hash.Update(buffer.AsSpan(offset, count));
 
-                var hash = new byte[Sha256.DigestSize];
+                byte[] hash = new byte[Sha256.DigestSize];
                 _hash.GetHash(hash);
 
                 if (Type == IntegrityStorageType.Save)

--- a/src/LibHac/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/FsSystem/NcaUtils/Nca.cs
@@ -52,7 +52,7 @@ namespace LibHac.FsSystem.NcaUtils
             }
 
             byte[] encryptedKey = Header.GetEncryptedKey(index).ToArray();
-            var decryptedKey = new byte[Aes.KeySize128];
+            byte[] decryptedKey = new byte[Aes.KeySize128];
 
             Aes.DecryptEcb128(encryptedKey, decryptedKey, keyAreaKey);
 
@@ -80,7 +80,7 @@ namespace LibHac.FsSystem.NcaUtils
             }
 
             byte[] encryptedKey = accessKey.Value.ToArray();
-            var decryptedKey = new byte[Aes.KeySize128];
+            byte[] decryptedKey = new byte[Aes.KeySize128];
 
             Aes.DecryptEcb128(encryptedKey, decryptedKey, titleKek);
 
@@ -636,7 +636,7 @@ namespace LibHac.FsSystem.NcaUtils
             else if (Header.FormatVersion == NcaVersion.Nca0RsaOaep)
             {
                 Span<byte> keyArea = Header.GetKeyArea();
-                var decKeyArea = new byte[0x100];
+                byte[] decKeyArea = new byte[0x100];
 
                 if (CryptoOld.DecryptRsaOaep(keyArea, decKeyArea, KeySet.BetaNca0KeyAreaKeyParams, out _))
                 {
@@ -708,7 +708,7 @@ namespace LibHac.FsSystem.NcaUtils
             IStorage bodyStorage = OpenNca0BodyStorage(false);
             long offset = Header.GetSectionStartOffset(index) - 0x400;
 
-            var fsHeaderData = new byte[0x200];
+            byte[] fsHeaderData = new byte[0x200];
             bodyStorage.Read(offset, fsHeaderData).ThrowIfFailure();
 
             return new NcaFsHeader(fsHeaderData);

--- a/src/LibHac/FsSystem/NcaUtils/NcaExtensions.cs
+++ b/src/LibHac/FsSystem/NcaUtils/NcaExtensions.cs
@@ -103,10 +103,10 @@ namespace LibHac.FsSystem.NcaUtils
                 offset += 0x200;
             }
 
-            var data = new byte[size];
+            byte[] data = new byte[size];
             storage.Read(offset, data).ThrowIfFailure();
 
-            var actualHash = new byte[Sha256.DigestSize];
+            byte[] actualHash = new byte[Sha256.DigestSize];
             Sha256.GenerateSha256Hash(data, actualHash);
 
             if (Utilities.ArraysEqual(expectedHash, actualHash)) return Validity.Valid;

--- a/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
+++ b/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
@@ -199,7 +199,7 @@ namespace LibHac.FsSystem.NcaUtils
 
         private static (byte[] header, bool isEncrypted) DecryptHeader(KeySet keySet, IStorage storage)
         {
-            var buf = new byte[HeaderSize];
+            byte[] buf = new byte[HeaderSize];
             storage.Read(0, buf).ThrowIfFailure();
 
             if (CheckIfDecrypted(buf))

--- a/src/LibHac/FsSystem/PartitionFileSystemBuilder.cs
+++ b/src/LibHac/FsSystem/PartitionFileSystemBuilder.cs
@@ -75,7 +75,7 @@ namespace LibHac.FsSystem
             int stringTableSize = CalcStringTableSize(HeaderSize + entryTableSize, type);
             int metaDataSize = HeaderSize + entryTableSize + stringTableSize;
 
-            var metaData = new byte[metaDataSize];
+            byte[] metaData = new byte[metaDataSize];
             var writer = new BinaryWriter(new MemoryStream(metaData));
 
             writer.WriteUTF8(GetMagicValue(type));
@@ -154,7 +154,7 @@ namespace LibHac.FsSystem
             {
                 if (entry.HashLength == 0) entry.HashLength = 0x200;
 
-                var data = new byte[entry.HashLength];
+                byte[] data = new byte[entry.HashLength];
                 entry.File.Read(out long bytesRead, entry.HashOffset, data);
 
                 if (bytesRead != entry.HashLength)

--- a/src/LibHac/FsSystem/RomFs/RomFsBuilder.cs
+++ b/src/LibHac/FsSystem/RomFs/RomFsBuilder.cs
@@ -80,7 +80,7 @@ namespace LibHac.FsSystem.RomFs
         {
             FileTable.TrimExcess();
 
-            var header = new byte[HeaderWithPaddingSize];
+            byte[] header = new byte[HeaderWithPaddingSize];
             var headerWriter = new BinaryWriter(new MemoryStream(header));
 
             var sources = new List<IStorage>();

--- a/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
+++ b/src/LibHac/FsSystem/RomFs/RomFsDictionary.cs
@@ -191,7 +191,7 @@ namespace LibHac.FsSystem.RomFs
 
             if (value != _capacity)
             {
-                var newBuffer = new byte[value];
+                byte[] newBuffer = new byte[value];
                 System.Buffer.BlockCopy(Entries, 0, newBuffer, 0, _length);
 
                 Entries = newBuffer;
@@ -223,7 +223,7 @@ namespace LibHac.FsSystem.RomFs
 
         private void Resize(int newSize)
         {
-            var newBuckets = new int[newSize];
+            int[] newBuckets = new int[newSize];
             newBuckets.AsSpan().Fill(-1);
 
             List<int> offsets = GetEntryOffsets();

--- a/src/LibHac/FsSystem/Save/Header.cs
+++ b/src/LibHac/FsSystem/Save/Header.cs
@@ -276,7 +276,7 @@ namespace LibHac.FsSystem.Save
 
         private static Guid ToGuid(byte[] bytes)
         {
-            var b = new byte[0x10];
+            byte[] b = new byte[0x10];
             Array.Copy(bytes, b, 0x10);
 
             // The Guid constructor uses a weird, mixed-endian format

--- a/src/LibHac/FsSystem/Save/SaveDataFileSystem.cs
+++ b/src/LibHac/FsSystem/Save/SaveDataFileSystem.cs
@@ -251,12 +251,12 @@ namespace LibHac.FsSystem.Save
 
             Stream headerStream = BaseStorage.AsStream();
 
-            var hashData = new byte[0x3d00];
+            byte[] hashData = new byte[0x3d00];
 
             headerStream.Position = 0x300;
             headerStream.Read(hashData, 0, hashData.Length);
 
-            var hash = new byte[Sha256.DigestSize];
+            byte[] hash = new byte[Sha256.DigestSize];
             Sha256.GenerateSha256Hash(hashData, hash);
 
             headerStream.Position = 0x108;
@@ -264,8 +264,8 @@ namespace LibHac.FsSystem.Save
 
             if (keySet == null || keySet.DeviceUniqueSaveMacKeys[0].IsZeros()) return ResultFs.PreconditionViolation.Log();
 
-            var cmacData = new byte[0x200];
-            var cmac = new byte[0x10];
+            byte[] cmacData = new byte[0x200];
+            byte[] cmac = new byte[0x10];
 
             headerStream.Position = 0x100;
             headerStream.Read(cmacData, 0, 0x200);

--- a/src/LibHac/FsSystem/StorageExtensions.cs
+++ b/src/LibHac/FsSystem/StorageExtensions.cs
@@ -170,7 +170,7 @@ namespace LibHac.FsSystem
 
             storage.GetSize(out long storageSize).ThrowIfFailure();
 
-            var arr = new byte[storageSize];
+            byte[] arr = new byte[storageSize];
             storage.CopyTo(new MemoryStorage(arr));
             return arr;
         }

--- a/src/LibHac/FsSystem/SubdirectoryFileSystem.cs
+++ b/src/LibHac/FsSystem/SubdirectoryFileSystem.cs
@@ -74,7 +74,7 @@ namespace LibHac.FsSystem
                 normalizedPathLen++;
             }
 
-            var buffer = new byte[normalizedPathLen + 1];
+            byte[] buffer = new byte[normalizedPathLen + 1];
             normalizedPath.Slice(0, (int)normalizedPathLen).CopyTo(buffer);
             RootPath = new U8String(buffer);
 

--- a/src/LibHac/Kip.cs
+++ b/src/LibHac/Kip.cs
@@ -49,7 +49,7 @@ namespace LibHac
             IStorage compStorage = OpenSection(index);
             compStorage.GetSize(out long compressedSize).ThrowIfFailure();
 
-            var compressed = new byte[compressedSize];
+            byte[] compressed = new byte[compressedSize];
             compStorage.Read(0, compressed).ThrowIfFailure();
 
             return DecompressBlz(compressed);
@@ -63,7 +63,7 @@ namespace LibHac
             int headerSize = BitConverter.ToInt32(compressed, compressed.Length - 8);
             int totalCompSize = BitConverter.ToInt32(compressed, compressed.Length - 12);
 
-            var decompressed = new byte[totalCompSize + additionalSize];
+            byte[] decompressed = new byte[totalCompSize + additionalSize];
 
             int inOffset = totalCompSize - headerSize;
             int outOffset = totalCompSize + additionalSize;

--- a/src/LibHac/Lz4.cs
+++ b/src/LibHac/Lz4.cs
@@ -8,7 +8,7 @@ namespace LibHac
     {
         public static byte[] Decompress(byte[] cmp, int decLength)
         {
-            var dec = new byte[decLength];
+            byte[] dec = new byte[decLength];
 
             int cmpPos = 0;
             int decPos = 0;

--- a/src/LibHac/Nso.cs
+++ b/src/LibHac/Nso.cs
@@ -84,7 +84,7 @@ namespace LibHac
 
             public byte[] DecompressSection()
             {
-                var compressed = new byte[CompressedSize];
+                byte[] compressed = new byte[CompressedSize];
                 OpenSection().Read(0, compressed).ThrowIfFailure();
 
                 if (IsCompressed)

--- a/src/LibHac/Package1.cs
+++ b/src/LibHac/Package1.cs
@@ -38,7 +38,7 @@ namespace LibHac
 
             // Try decrypting the PK11 blob with all known package1 keys
             IStorage encStorage = Storage.Slice(0x4000, Pk11Size);
-            var decBuffer = new byte[0x10];
+            byte[] decBuffer = new byte[0x10];
 
             for (int i = 0; i < 0x20; i++)
             {

--- a/src/LibHac/Package2.cs
+++ b/src/LibHac/Package2.cs
@@ -67,7 +67,7 @@ namespace LibHac
 
             // The counter starts counting at 0x100, but the block at 0x100 isn't encrypted.
             // Increase the counter by one and start decrypting at 0x110.
-            var counter = new byte[0x10];
+            byte[] counter = new byte[0x10];
             Array.Copy(Header.Counter, counter, 0x10);
             Utilities.IncrementByteArray(counter);
 
@@ -109,8 +109,8 @@ namespace LibHac
 
         private int FindKeyGeneration(KeySet keySet, IStorage storage)
         {
-            var counter = new byte[0x10];
-            var decBuffer = new byte[0x10];
+            byte[] counter = new byte[0x10];
+            byte[] decBuffer = new byte[0x10];
 
             storage.Read(0x100, counter).ThrowIfFailure();
 

--- a/src/LibHac/Ticket.cs
+++ b/src/LibHac/Ticket.cs
@@ -150,7 +150,7 @@ namespace LibHac
         {
             if (TitleKeyType == TitleKeyType.Common)
             {
-                var commonKey = new byte[0x10];
+                byte[] commonKey = new byte[0x10];
                 Array.Copy(TitleKeyBlock, commonKey, commonKey.Length);
                 return commonKey;
             }

--- a/src/LibHac/Util/StringUtils.cs
+++ b/src/LibHac/Util/StringUtils.cs
@@ -223,7 +223,7 @@ namespace LibHac.Util
             if ((uint)input.Length % 2 != 0)
                 throw new FormatException("Hex input must be a multiple of 2.");
 
-            var result = new byte[input.Length >> 1];
+            byte[] result = new byte[input.Length >> 1];
 
             if (!HexConverter.TryDecodeFromUtf16(input, result))
             {

--- a/src/LibHac/Utilities.cs
+++ b/src/LibHac/Utilities.cs
@@ -105,7 +105,7 @@ namespace LibHac
         {
             const int bufferSize = 0x8000;
             long remaining = length;
-            var buffer = new byte[bufferSize];
+            byte[] buffer = new byte[bufferSize];
             progress?.SetTotal(length);
 
             int read;

--- a/src/LibHac/XciHeader.cs
+++ b/src/LibHac/XciHeader.cs
@@ -111,22 +111,22 @@ namespace LibHac
                 if (keySet != null && !keySet.XciHeaderKey.IsZeros())
                 {
                     byte[] encHeader = reader.ReadBytes(EncryptedHeaderSize);
-                    var decHeader = new byte[EncryptedHeaderSize];
+                    byte[] decHeader = new byte[EncryptedHeaderSize];
                     Aes.DecryptCbc128(encHeader, decHeader, keySet.XciHeaderKey, AesCbcIv);
 
-                    using (var decreader = new BinaryReader(new MemoryStream(decHeader)))
+                    using (var decReader = new BinaryReader(new MemoryStream(decHeader)))
                     {
-                        FwVersion = decreader.ReadUInt64();
-                        AccCtrl1 = (CardClockRate)decreader.ReadInt32();
-                        Wait1TimeRead = decreader.ReadInt32();
-                        Wait2TimeRead = decreader.ReadInt32();
-                        Wait1TimeWrite = decreader.ReadInt32();
-                        Wait2TimeWrite = decreader.ReadInt32();
-                        FwMode = decreader.ReadInt32();
-                        UppVersion = decreader.ReadInt32();
-                        decreader.BaseStream.Position += 4;
-                        UppHash = decreader.ReadBytes(8);
-                        UppId = decreader.ReadUInt64();
+                        FwVersion = decReader.ReadUInt64();
+                        AccCtrl1 = (CardClockRate)decReader.ReadInt32();
+                        Wait1TimeRead = decReader.ReadInt32();
+                        Wait2TimeRead = decReader.ReadInt32();
+                        Wait1TimeWrite = decReader.ReadInt32();
+                        Wait2TimeWrite = decReader.ReadInt32();
+                        FwMode = decReader.ReadInt32();
+                        UppVersion = decReader.ReadInt32();
+                        decReader.BaseStream.Position += 4;
+                        UppHash = decReader.ReadBytes(8);
+                        UppId = decReader.ReadUInt64();
                     }
                 }
 

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -9,12 +9,12 @@ namespace hactoolnet
     {
         private static CliOption[] GetCliOptions() => new[]
         {
-            new CliOption("custom", 0, (o, a) => o.RunCustom = true),
+            new CliOption("custom", 0, (o, _) => o.RunCustom = true),
             new CliOption("intype", 't', 1, (o, a) => o.InFileType = ParseFileType(a[0])),
-            new CliOption("raw", 'r', 0, (o, a) => o.Raw = true),
-            new CliOption("verify", 'y', 0, (o, a) => o.Validate = true),
-            new CliOption("dev", 'd', 0, (o, a) => o.UseDevKeys = true),
-            new CliOption("enablehash", 'h', 0, (o, a) => o.EnableHash = true),
+            new CliOption("raw", 'r', 0, (o, _) => o.Raw = true),
+            new CliOption("verify", 'y', 0, (o, _) => o.Validate = true),
+            new CliOption("dev", 'd', 0, (o, _) => o.UseDevKeys = true),
+            new CliOption("enablehash", 'h', 0, (o, _) => o.EnableHash = true),
             new CliOption("keyset", 'k', 1, (o, a) => o.Keyfile = a[0]),
             new CliOption("titlekeys", 1, (o, a) => o.TitleKeyFile = a[0]),
             new CliOption("consolekeys", 1, (o, a) => o.ConsoleKeyFile = a[0]),
@@ -52,16 +52,16 @@ namespace hactoolnet
             new CliOption("securedir", 1, (o, a) => o.SecureDir = a[0]),
             new CliOption("logodir", 1, (o, a) => o.LogoDir = a[0]),
             new CliOption("repack", 1, (o, a) => o.RepackSource = a[0]),
-            new CliOption("listapps", 0, (o, a) => o.ListApps = true),
-            new CliOption("listtitles", 0, (o, a) => o.ListTitles = true),
-            new CliOption("listncas", 0, (o, a) => o.ListNcas = true),
-            new CliOption("listromfs", 0, (o, a) => o.ListRomFs = true),
-            new CliOption("listfiles", 0, (o, a) => o.ListFiles = true),
-            new CliOption("sign", 0, (o, a) => o.SignSave = true),
-            new CliOption("trim", 0, (o, a) => o.TrimSave = true),
-            new CliOption("readbench", 0, (o, a) => o.ReadBench = true),
-            new CliOption("hashedfs", 0, (o, a) => o.BuildHfs = true),
-            new CliOption("extractini1", 0, (o, a) => o.ExtractIni1 = true),
+            new CliOption("listapps", 0, (o, _) => o.ListApps = true),
+            new CliOption("listtitles", 0, (o, _) => o.ListTitles = true),
+            new CliOption("listncas", 0, (o, _) => o.ListNcas = true),
+            new CliOption("listromfs", 0, (o, _) => o.ListRomFs = true),
+            new CliOption("listfiles", 0, (o, _) => o.ListFiles = true),
+            new CliOption("sign", 0, (o, _) => o.SignSave = true),
+            new CliOption("trim", 0, (o, _) => o.TrimSave = true),
+            new CliOption("readbench", 0, (o, _) => o.ReadBench = true),
+            new CliOption("hashedfs", 0, (o, _) => o.BuildHfs = true),
+            new CliOption("extractini1", 0, (o, _) => o.ExtractIni1 = true),
             new CliOption("title", 1, (o, a) => o.TitleId = ParseTitleId(a[0])),
             new CliOption("bench", 1, (o, a) => o.BenchType = a[0]),
             new CliOption("cpufreq", 1, (o, a) => o.CpuFrequencyGhz = ParseDouble(a[0])),
@@ -118,7 +118,7 @@ namespace hactoolnet
                     return null;
                 }
 
-                var optionArgs = new string[option.ArgsNeeded];
+                string[] optionArgs = new string[option.ArgsNeeded];
                 Array.Copy(args, i + 1, optionArgs, 0, option.ArgsNeeded);
 
                 option.Assigner(options, optionArgs);

--- a/src/hactoolnet/Print.cs
+++ b/src/hactoolnet/Print.cs
@@ -106,7 +106,7 @@ namespace hactoolnet
 
         public static string MagicToString(uint value)
         {
-            var buf = new byte[4];
+            byte[] buf = new byte[4];
             BinaryPrimitives.WriteUInt32LittleEndian(buf, value);
 
             return Encoding.ASCII.GetString(buf);

--- a/src/hactoolnet/ProcessBench.cs
+++ b/src/hactoolnet/ProcessBench.cs
@@ -53,7 +53,7 @@ namespace hactoolnet
             cipherGenerator().Transform(src, dst);
 
             var watch = new Stopwatch();
-            var runTimes = new double[iterations];
+            double[] runTimes = new double[iterations];
 
             logger.SetTotal(iterations);
 
@@ -90,7 +90,7 @@ namespace hactoolnet
             cipherGenerator().Transform(src, dst);
 
             var watch = new Stopwatch();
-            var runTimes = new double[iterations];
+            double[] runTimes = new double[iterations];
 
             logger.SetTotal(iterations);
 
@@ -139,7 +139,7 @@ namespace hactoolnet
             Debug.Assert(src.Length == dst.Length);
 
             var watch = new Stopwatch();
-            var runTimes = new double[iterations];
+            double[] runTimes = new double[iterations];
 
             ReadOnlySpan<byte> key1 = stackalloc byte[0x10];
             ReadOnlySpan<byte> key2 = stackalloc byte[0x10];
@@ -183,8 +183,8 @@ namespace hactoolnet
 
         private static void RegisterAesSequentialBenchmarks(MultiBenchmark bench)
         {
-            var input = new byte[BatchCipherBenchSize];
-            var output = new byte[BatchCipherBenchSize];
+            byte[] input = new byte[BatchCipherBenchSize];
+            byte[] output = new byte[BatchCipherBenchSize];
 
             Func<double, string> resultPrinter = time => GetPerformanceString(time, BatchCipherBenchSize);
 
@@ -231,8 +231,8 @@ namespace hactoolnet
         // ReSharper disable once UnusedParameter.Local
         private static void RegisterAesSingleBlockBenchmarks(MultiBenchmark bench)
         {
-            var input = new byte[SingleBlockCipherBenchSize];
-            var output = new byte[SingleBlockCipherBenchSize];
+            byte[] input = new byte[SingleBlockCipherBenchSize];
+            byte[] output = new byte[SingleBlockCipherBenchSize];
 
             Func<double, string> resultPrinter = time => GetPerformanceString(time, SingleBlockCipherBenchSize);
 
@@ -284,8 +284,8 @@ namespace hactoolnet
 
         private static void RegisterShaBenchmarks(MultiBenchmark bench)
         {
-            var input = new byte[ShaBenchSize];
-            var digest = new byte[Sha256.DigestSize];
+            byte[] input = new byte[ShaBenchSize];
+            byte[] digest = new byte[Sha256.DigestSize];
 
             Func<double, string> resultPrinter = time => GetPerformanceString(time, ShaBenchSize);
 
@@ -314,14 +314,14 @@ namespace hactoolnet
         private static void RunCipherBenchmark(Func<ICipher> cipherNet, Func<ICipher> cipherLibHac,
             CipherTaskSeparate function, bool benchBlocked, string label, IProgressReport logger)
         {
-            var srcData = new byte[Size];
+            byte[] srcData = new byte[Size];
 
-            var dstDataLh = new byte[Size];
-            var dstDataNet = new byte[Size];
-            var dstDataBlockedLh = new byte[Size];
-            var dstDataBlockedNet = new byte[Size];
-            var dstDataSeparateLh = new byte[Size];
-            var dstDataSeparateNet = new byte[Size];
+            byte[] dstDataLh = new byte[Size];
+            byte[] dstDataNet = new byte[Size];
+            byte[] dstDataBlockedLh = new byte[Size];
+            byte[] dstDataBlockedNet = new byte[Size];
+            byte[] dstDataSeparateLh = new byte[Size];
+            byte[] dstDataSeparateNet = new byte[Size];
 
             logger.LogMessage(string.Empty);
             logger.LogMessage(label);
@@ -437,14 +437,14 @@ namespace hactoolnet
                 {
                     Func<ICipher> encryptorNet = () => Aes.CreateEcbEncryptor(new byte[0x10], true);
                     Func<ICipher> encryptorLh = () => Aes.CreateEcbEncryptor(new byte[0x10]);
-                    CipherTaskSeparate encrypt = (input, output, key1, key2, iv, crypto) =>
+                    CipherTaskSeparate encrypt = (input, output, key1, _, _, crypto) =>
                         Aes.EncryptEcb128(input, output, key1, crypto);
 
                     RunCipherBenchmark(encryptorNet, encryptorLh, encrypt, true, "AES-ECB encrypt", ctx.Logger);
 
                     Func<ICipher> decryptorNet = () => Aes.CreateEcbDecryptor(new byte[0x10], true);
                     Func<ICipher> decryptorLh = () => Aes.CreateEcbDecryptor(new byte[0x10]);
-                    CipherTaskSeparate decrypt = (input, output, key1, key2, iv, crypto) =>
+                    CipherTaskSeparate decrypt = (input, output, key1, _, _, crypto) =>
                         Aes.DecryptEcb128(input, output, key1, crypto);
 
                     RunCipherBenchmark(decryptorNet, decryptorLh, decrypt, true, "AES-ECB decrypt", ctx.Logger);
@@ -456,14 +456,14 @@ namespace hactoolnet
                 {
                     Func<ICipher> encryptorNet = () => Aes.CreateCbcEncryptor(new byte[0x10], new byte[0x10], true);
                     Func<ICipher> encryptorLh = () => Aes.CreateCbcEncryptor(new byte[0x10], new byte[0x10]);
-                    CipherTaskSeparate encrypt = (input, output, key1, key2, iv, crypto) =>
+                    CipherTaskSeparate encrypt = (input, output, key1, _, iv, crypto) =>
                         Aes.EncryptCbc128(input, output, key1, iv, crypto);
 
                     RunCipherBenchmark(encryptorNet, encryptorLh, encrypt, true, "AES-CBC encrypt", ctx.Logger);
 
                     Func<ICipher> decryptorNet = () => Aes.CreateCbcDecryptor(new byte[0x10], new byte[0x10], true);
                     Func<ICipher> decryptorLh = () => Aes.CreateCbcDecryptor(new byte[0x10], new byte[0x10]);
-                    CipherTaskSeparate decrypt = (input, output, key1, key2, iv, crypto) =>
+                    CipherTaskSeparate decrypt = (input, output, key1, _, iv, crypto) =>
                         Aes.DecryptCbc128(input, output, key1, iv, crypto);
 
                     RunCipherBenchmark(decryptorNet, decryptorLh, decrypt, true, "AES-CBC decrypt", ctx.Logger);
@@ -475,7 +475,7 @@ namespace hactoolnet
                 {
                     Func<ICipher> encryptorNet = () => Aes.CreateCtrEncryptor(new byte[0x10], new byte[0x10], true);
                     Func<ICipher> encryptorLh = () => Aes.CreateCtrEncryptor(new byte[0x10], new byte[0x10]);
-                    CipherTaskSeparate encrypt = (input, output, key1, key2, iv, crypto) =>
+                    CipherTaskSeparate encrypt = (input, output, key1, _, iv, crypto) =>
                         Aes.EncryptCtr128(input, output, key1, iv, crypto);
 
                     RunCipherBenchmark(encryptorNet, encryptorLh, encrypt, true, "AES-CTR", ctx.Logger);

--- a/src/hactoolnet/ProcessKip.cs
+++ b/src/hactoolnet/ProcessKip.cs
@@ -16,7 +16,7 @@ namespace hactoolnet
 
                 if (!string.IsNullOrWhiteSpace(ctx.Options.UncompressedOut))
                 {
-                    var uncompressed = new byte[kip.GetUncompressedSize()];
+                    byte[] uncompressed = new byte[kip.GetUncompressedSize()];
 
                     kip.ReadUncompressedKip(uncompressed).ThrowIfFailure();
 

--- a/src/hactoolnet/TableBuilder.cs
+++ b/src/hactoolnet/TableBuilder.cs
@@ -33,7 +33,7 @@ namespace hactoolnet
         public string Print()
         {
             var sb = new StringBuilder();
-            var width = new int[ColumnCount];
+            int[] width = new int[ColumnCount];
 
             foreach (string[] row in Rows)
             {

--- a/tests/LibHac.Tests/AesCmac.cs
+++ b/tests/LibHac.Tests/AesCmac.cs
@@ -58,7 +58,7 @@ namespace LibHac.Tests
         [MemberData(nameof(TestVectors))]
         public static void TestCmacTestVectors(TestData data)
         {
-            var actual = new byte[0x10];
+            byte[] actual = new byte[0x10];
 
             Aes.CalculateCmac(actual, data.Message.AsSpan(data.Start, data.Length), data.Key);
 

--- a/tests/LibHac.Tests/CryptoTests/Common.cs
+++ b/tests/LibHac.Tests/CryptoTests/Common.cs
@@ -8,7 +8,7 @@ namespace LibHac.Tests.CryptoTests
     {
         internal static void CipherTestCore(byte[] inputData, byte[] expected, ICipher cipher)
         {
-            var transformBuffer = new byte[inputData.Length];
+            byte[] transformBuffer = new byte[inputData.Length];
             Buffer.BlockCopy(inputData, 0, transformBuffer, 0, inputData.Length);
 
             cipher.Transform(transformBuffer, transformBuffer);
@@ -19,7 +19,7 @@ namespace LibHac.Tests.CryptoTests
         internal static void HashTestCore(ReadOnlySpan<byte> message, byte[] expectedDigest, IHash hash)
         {
 
-            var digestBuffer = new byte[Sha256.DigestSize];
+            byte[] digestBuffer = new byte[Sha256.DigestSize];
 
             hash.Initialize();
             hash.Update(message);

--- a/tests/LibHac.Tests/Fs/AesXtsFileSystemTests.cs
+++ b/tests/LibHac.Tests/Fs/AesXtsFileSystemTests.cs
@@ -11,7 +11,7 @@ namespace LibHac.Tests.Fs
         {
             var baseFs = new InMemoryFileSystem();
 
-            var keys = new byte[0x20];
+            byte[] keys = new byte[0x20];
             var xtsFs = new AesXtsFileSystem(baseFs, keys, 0x4000);
 
             return xtsFs;

--- a/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/SaveDataManagement.cs
+++ b/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/SaveDataManagement.cs
@@ -80,7 +80,7 @@ namespace LibHac.Tests.Fs.FileSystemClientTests.ShimTests
             Assert.Equal(applicationId, info[0].ProgramId);
             Assert.Equal(applicationId, info[1].ProgramId);
 
-            var expectedIndexes = new ushort[] { 0, 1 };
+            ushort[] expectedIndexes = { 0, 1 };
             ushort[] actualIndexes = info.Take(2).Select(x => x.Index).OrderBy(x => x).ToArray();
 
             Assert.Equal(expectedIndexes, actualIndexes);

--- a/tests/LibHac.Tests/Fs/IFileSystemTestBase/CommittableIFileSystemTests.Commit.cs
+++ b/tests/LibHac.Tests/Fs/IFileSystemTestBase/CommittableIFileSystemTests.Commit.cs
@@ -11,8 +11,8 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
         public void Commit_AfterSuccessfulCommit_CanReadCommittedData()
         {
             // "Random" test data
-            var data1 = new byte[] { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
-            var data2 = new byte[] { 6, 1, 6, 8, 0, 3, 9, 7, 5, 1 };
+            byte[] data1 = { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
+            byte[] data2 = { 6, 1, 6, 8, 0, 3, 9, 7, 5, 1 };
 
             IReopenableFileSystemCreator fsCreator = GetFileSystemCreator();
             IFileSystem fs = fsCreator.Create();
@@ -39,8 +39,8 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
             // Reopen after committing
             fs = fsCreator.Create();
 
-            var readData1 = new byte[data1.Length];
-            var readData2 = new byte[data2.Length];
+            byte[] readData1 = new byte[data1.Length];
+            byte[] readData2 = new byte[data2.Length];
 
             Assert.Success(fs.OpenFile(out file1, "/dir1/file".ToU8Span(), OpenMode.Read));
 
@@ -101,8 +101,8 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
         public void Rollback_AfterChangingExistingFiles_GoesBackToOriginalData()
         {
             // "Random" test data
-            var data1 = new byte[] { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
-            var data2 = new byte[] { 6, 1, 6, 8, 0, 3, 9, 7, 5, 1 };
+            byte[] data1 = { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
+            byte[] data2 = { 6, 1, 6, 8, 0, 3, 9, 7, 5, 1 };
 
             IReopenableFileSystemCreator fsCreator = GetFileSystemCreator();
             IFileSystem fs = fsCreator.Create();
@@ -128,7 +128,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
             Assert.Success(fs.Rollback());
 
             // The file should contain the original data after the rollback
-            var readData = new byte[data1.Length];
+            byte[] readData = new byte[data1.Length];
 
             Assert.Success(fs.OpenFile(out file, "/dir/file".ToU8Span(), OpenMode.Read));
 

--- a/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.IFile.Read.cs
+++ b/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.IFile.Read.cs
@@ -15,7 +15,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 100, CreateFileOptions.None);
 
-            var buffer = new byte[20];
+            byte[] buffer = new byte[20];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -31,7 +31,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 0, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -47,7 +47,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 0, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Write);
             using (file)
             {
@@ -63,7 +63,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 0, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Write);
             using (file)
             {
@@ -79,7 +79,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 0, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Write);
             using (file)
             {
@@ -95,7 +95,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 100, CreateFileOptions.None);
 
-            var buffer = new byte[200];
+            byte[] buffer = new byte[200];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -118,10 +118,10 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
                 file.Write(0, new byte[100], WriteOption.None);
             }
 
-            var bufferExpected = new byte[200];
+            byte[] bufferExpected = new byte[200];
             bufferExpected.AsSpan(10).Fill(0xCC);
 
-            var buffer = new byte[200];
+            byte[] buffer = new byte[200];
             buffer.AsSpan().Fill(0xCC);
 
             fs.OpenFile(out file, "/file".ToU8Span(), OpenMode.Read);

--- a/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.IFile.Write.cs
+++ b/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.IFile.Write.cs
@@ -11,7 +11,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
         [Fact]
         public void IFileWrite_CanReadBackWrittenData()
         {
-            var data = new byte[] { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
+            byte[] data = { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
 
             IFileSystem fs = CreateFileSystem();
 
@@ -21,7 +21,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
             file.Write(0, data, WriteOption.None);
             file.Dispose();
 
-            var readData = new byte[data.Length];
+            byte[] readData = new byte[data.Length];
 
             fs.OpenFile(out file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
@@ -40,7 +40,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Write);
             using (file)
             {
@@ -56,7 +56,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -72,7 +72,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -88,7 +88,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.Read);
             using (file)
             {
@@ -104,7 +104,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.All);
             using (file)
             {
@@ -122,7 +122,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var buffer = new byte[10];
+            byte[] buffer = new byte[10];
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.All);
             using (file)
             {
@@ -140,10 +140,10 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.CreateFile("/file".ToU8Span(), 10, CreateFileOptions.None);
 
-            var bufferExpected = new byte[25];
+            byte[] bufferExpected = new byte[25];
             bufferExpected.AsSpan(15).Fill(0xCC);
 
-            var writeBuffer = new byte[10];
+            byte[] writeBuffer = new byte[10];
             writeBuffer.AsSpan().Fill(0xCC);
 
             fs.OpenFile(out IFile file, "/file".ToU8Span(), OpenMode.All);
@@ -155,7 +155,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
                 file.Write(0, new byte[15], WriteOption.None);
             }
 
-            var readBuffer = new byte[25];
+            byte[] readBuffer = new byte[25];
 
             fs.OpenFile(out file, "/file".ToU8Span(), OpenMode.Read);
             using (file)

--- a/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.RenameFile.cs
+++ b/tests/LibHac.Tests/Fs/IFileSystemTestBase/IFileSystemTests.RenameFile.cs
@@ -92,7 +92,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
         [Fact]
         public void RenameFile_DataIsUnmodified()
         {
-            var data = new byte[] { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
+            byte[] data = { 7, 4, 1, 0, 8, 5, 2, 9, 6, 3 };
 
             IFileSystem fs = CreateFileSystem();
 
@@ -104,7 +104,7 @@ namespace LibHac.Tests.Fs.IFileSystemTestBase
 
             fs.RenameFile("/file".ToU8Span(), "/renamed".ToU8Span());
 
-            var readData = new byte[data.Length];
+            byte[] readData = new byte[data.Length];
 
             fs.OpenFile(out file, "/renamed".ToU8Span(), OpenMode.Read);
             Result rc = file.Read(out long bytesRead, 0, readData, ReadOption.None);

--- a/tests/LibHac.Tests/Fs/PathToolTests.cs
+++ b/tests/LibHac.Tests/Fs/PathToolTests.cs
@@ -12,7 +12,7 @@ namespace LibHac.Tests.Fs
         public static void Normalize(string path, bool preserveUnc, bool hasMountName, string expectedNormalized,
             long expectedLength, Result expectedResult)
         {
-            var buffer = new byte[0x301];
+            byte[] buffer = new byte[0x301];
 
             Result result = PathTool.Normalize(buffer, out long normalizedLength, path.ToU8Span(), preserveUnc,
                 hasMountName);

--- a/tests/LibHac.Tests/Kvdb/FlatMapKeyValueStoreTests.cs
+++ b/tests/LibHac.Tests/Kvdb/FlatMapKeyValueStoreTests.cs
@@ -41,11 +41,11 @@ namespace LibHac.Tests.Kvdb
 
         private static byte[][] GenerateValues(int count, int startingSize)
         {
-            var values = new byte[count][];
+            byte[][] values = new byte[count][];
 
             for (int i = 0; i < count; i++)
             {
-                var value = new byte[startingSize + i];
+                byte[] value = new byte[startingSize + i];
                 value.AsSpan().Fill((byte)count);
                 values[i] = value;
             }
@@ -189,7 +189,7 @@ namespace LibHac.Tests.Kvdb
             Assert.Success(PopulateKvStore(kvStore, out _, count));
 
             TTest key = 20;
-            var value = new byte[20];
+            byte[] value = new byte[20];
 
             Result rc = kvStore.Get(out int _, in key, value);
             Assert.Result(ResultKvdb.KeyNotFound, rc);
@@ -206,7 +206,7 @@ namespace LibHac.Tests.Kvdb
             Assert.Success(PopulateKvStore(kvStore, out _, count, startingValueSize, rngSeed));
 
             // Check the size of each entry
-            var value = new byte[100];
+            byte[] value = new byte[100];
 
             for (TTest i = 0; i < count; i++)
             {
@@ -226,7 +226,7 @@ namespace LibHac.Tests.Kvdb
             Assert.Success(PopulateKvStore(kvStore, out byte[][] values, count, startingValueSize, rngSeed));
 
             // Check if each value matches
-            var value = new byte[100];
+            byte[] value = new byte[100];
 
             for (int i = 0; i < count; i++)
             {
@@ -263,13 +263,13 @@ namespace LibHac.Tests.Kvdb
             Assert.Success(PopulateKvStore(kvStore, out _, count));
 
             TTest key = entryToReplace;
-            var value = new byte[15];
+            byte[] value = new byte[15];
             value.AsSpan().Fill(0xFF);
 
             Assert.Success(kvStore.Set(in key, value));
 
             // Read back the value
-            var readValue = new byte[20];
+            byte[] readValue = new byte[20];
             Assert.Success(kvStore.Get(out int valueSize, in key, readValue));
 
             // Check the value contents and size
@@ -347,7 +347,7 @@ namespace LibHac.Tests.Kvdb
             TTest keyToDelete = entryToDelete;
             Assert.Success(kvStore.Delete(in keyToDelete));
 
-            var value = new byte[20];
+            byte[] value = new byte[20];
 
             Result rc = kvStore.Get(out int _, in keyToDelete, value);
             Assert.Result(ResultKvdb.KeyNotFound, rc);
@@ -515,7 +515,7 @@ namespace LibHac.Tests.Kvdb
             }
 
             TTest keyToAdd = entryToAdd;
-            var valueToAdd = new byte[10];
+            byte[] valueToAdd = new byte[10];
 
             Assert.Success(kvStore.Set(in keyToAdd, valueToAdd));
 


### PR DESCRIPTION
ReSharper 2020.Something modified the `var` style again so that arrays of built-in types also count as built-in types, meaning the type should always be explicit.