### PR TITLE
Add new assert system

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ $env:DOTNET_MULTILEVEL_LOOKUP = 0
 ###########################################################################
 
 function ExecSafe([scriptblock] $cmd) {
-    $LASTEXITCODE = 0
+    $global:LASTEXITCODE = 0
     & $cmd
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }

--- a/src/LibHac/Boot/Package1.cs
+++ b/src/LibHac/Boot/Package1.cs
@@ -335,7 +335,7 @@ namespace LibHac.Boot
 
         private bool VerifyPk11Sizes()
         {
-            Assert.True(IsDecrypted);
+            Assert.SdkRequires(IsDecrypted);
 
             int pk11Size = Unsafe.SizeOf<Package1Pk11Header>() + GetSectionSize(Package1Section.WarmBoot) +
                     GetSectionSize(Package1Section.Bootloader) + GetSectionSize(Package1Section.SecureMonitor);

--- a/src/LibHac/Common/Keys/ExternalKeyReader.cs
+++ b/src/LibHac/Common/Keys/ExternalKeyReader.cs
@@ -493,8 +493,8 @@ namespace LibHac.Common.Keys
             // of the file which will be treated as the end of a line.
             if (state == ReaderState.Value || state == ReaderState.WhiteSpace2)
             {
-                Assert.True(i == buffer.Length);
-                Assert.True(reader.HasReadEndOfFile);
+                Assert.SdkEqual(i, buffer.Length);
+                Assert.SdkAssert(reader.HasReadEndOfFile);
 
                 // WhiteSpace2 will have already set this value
                 if (state == ReaderState.Value)
@@ -506,8 +506,8 @@ namespace LibHac.Common.Keys
             // Same situation as the two above states
             if (state == ReaderState.Comment)
             {
-                Assert.True(i == buffer.Length);
-                Assert.True(reader.HasReadEndOfFile);
+                Assert.SdkEqual(i, buffer.Length);
+                Assert.SdkAssert(reader.HasReadEndOfFile);
 
                 keyLength = i - keyOffset;
                 state = ReaderState.CommentSuccess;
@@ -516,8 +516,8 @@ namespace LibHac.Common.Keys
             // Same as the above states except the final line was empty or whitespace.
             if (state == ReaderState.Initial)
             {
-                Assert.True(i == buffer.Length);
-                Assert.True(reader.HasReadEndOfFile);
+                Assert.SdkEqual(i, buffer.Length);
+                Assert.SdkAssert(reader.HasReadEndOfFile);
 
                 reader.BufferPos = i;
                 return ReaderStatus.NoKeyRead;

--- a/src/LibHac/Common/Keys/KeyInfo.cs
+++ b/src/LibHac/Common/Keys/KeyInfo.cs
@@ -48,7 +48,7 @@ namespace LibHac.Common.Keys
 
         public KeyInfo(int group, KeyType type, string name, KeyGetter retrieveFunc)
         {
-            Assert.True(IsKeyTypeValid(type));
+            Assert.SdkRequires(IsKeyTypeValid(type));
 
             Name = name;
             RangeType = KeyRangeType.Single;
@@ -61,7 +61,7 @@ namespace LibHac.Common.Keys
 
         public KeyInfo(int group, KeyType type, string name, byte rangeStart, byte rangeEnd, KeyGetter retrieveFunc)
         {
-            Assert.True(IsKeyTypeValid(type));
+            Assert.SdkRequires(IsKeyTypeValid(type));
 
             Name = name;
             RangeType = KeyRangeType.Range;
@@ -87,7 +87,7 @@ namespace LibHac.Common.Keys
 
         private bool MatchesSingle(ReadOnlySpan<char> keyName, out bool isDev)
         {
-            Assert.Equal((int)KeyRangeType.Single, (int)RangeType);
+            Assert.SdkRequiresEqual((int)KeyRangeType.Single, (int)RangeType);
 
             isDev = false;
 
@@ -113,7 +113,7 @@ namespace LibHac.Common.Keys
 
         private bool MatchesRangedKey(ReadOnlySpan<char> keyName, ref int keyIndex, out bool isDev)
         {
-            Assert.Equal((int)KeyRangeType.Range, (int)RangeType);
+            Assert.SdkRequiresEqual((int)KeyRangeType.Range, (int)RangeType);
 
             isDev = false;
 

--- a/src/LibHac/Common/U8StringBuilder.cs
+++ b/src/LibHac/Common/U8StringBuilder.cs
@@ -173,7 +173,7 @@ namespace LibHac.Common
                 // Grow the buffer and try again. The buffer size will at least double each time it grows,
                 // so asking for 0x10 additional bytes actually gets us more than that.
                 Grow(availableBuffer.Length + 0x10);
-                Assert.True(Length + availableBuffer.Length < Capacity);
+                Assert.SdkGreater(Capacity, Length + availableBuffer.Length);
             }
 
             PadOutput(bytesWritten);
@@ -212,7 +212,7 @@ namespace LibHac.Common
                 }
 
                 Grow(availableBuffer.Length + 0x10);
-                Assert.True(Length + availableBuffer.Length < Capacity);
+                Assert.SdkGreater(Capacity, Length + availableBuffer.Length);
             }
 
             PadOutput(bytesWritten);
@@ -251,7 +251,7 @@ namespace LibHac.Common
                 }
 
                 Grow(availableBuffer.Length + 0x10);
-                Assert.True(Length + availableBuffer.Length < Capacity);
+                Assert.SdkGreater(Capacity, Length + availableBuffer.Length);
             }
 
             PadOutput(bytesWritten);
@@ -290,7 +290,7 @@ namespace LibHac.Common
                 }
 
                 Grow(availableBuffer.Length + 0x10);
-                Assert.True(Length + availableBuffer.Length < Capacity);
+                Assert.SdkGreater(Capacity, Length + availableBuffer.Length);
             }
 
             PadOutput(bytesWritten);
@@ -368,7 +368,7 @@ namespace LibHac.Common
             if (!hasCapacity && AutoExpand)
             {
                 Grow(requiredAfterPadding);
-                Assert.True(HasCapacity(Length + requiredAfterPadding));
+                Assert.SdkAssert(HasCapacity(Length + requiredAfterPadding));
                 hasCapacity = true;
             }
 

--- a/src/LibHac/Crypto/Aes.cs
+++ b/src/LibHac/Crypto/Aes.cs
@@ -296,7 +296,7 @@ namespace LibHac.Crypto
 
         private static void LeftShiftBytes(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Assert.True(output.Length >= input.Length);
+            Assert.SdkRequiresGreaterEqual(output.Length, input.Length);
 
             byte carry = 0;
 

--- a/src/LibHac/Diag/Abort.cs
+++ b/src/LibHac/Diag/Abort.cs
@@ -3,8 +3,32 @@ using System.Runtime.CompilerServices;
 
 namespace LibHac.Diag
 {
+    public ref struct AbortInfo
+    {
+        public AbortReason AbortReason;
+        public string Message;
+        public string Condition;
+        public string FunctionName;
+        public string FileName;
+        public int LineNumber;
+    }
+
+    public enum AbortReason
+    {
+        SdkAssert,
+        SdkRequires,
+        UserAssert,
+        Abort,
+        UnexpectedDefault
+    }
+
     public static class Abort
     {
+        internal static void InvokeAbortObserver(in AbortInfo abortInfo)
+        {
+            // Todo
+        }
+
         [DoesNotReturn]
         public static void DoAbort(Result result, string message = null)
         {

--- a/src/LibHac/Diag/Assert.cs
+++ b/src/LibHac/Diag/Assert.cs
@@ -1,86 +1,1093 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using LibHac.Diag.Impl;
+using LibHac.Os;
 
 namespace LibHac.Diag
 {
+    public ref struct AssertionInfo
+    {
+        public AssertionType AssertionType;
+        public string Message;
+        public string Condition;
+        public string FunctionName;
+        public string FileName;
+        public int LineNumber;
+    }
+
+    public enum AssertionType
+    {
+        SdkAssert,
+        SdkRequires,
+        UserAssert
+    }
+
+    public enum AssertionFailureOperation
+    {
+        Abort,
+        Continue
+    }
+
+    public delegate AssertionFailureOperation AssertionFailureHandler(in AssertionInfo assertionInfo);
+
     public static class Assert
     {
-        [Conditional("DEBUG")]
-        public static void True([DoesNotReturnIf(false)] bool condition, string message = null)
+        private const string AssertCondition = "ENABLE_ASSERTS";
+
+        private static SdkMutexType _mutex = InitMutex();
+        private static AssertionFailureHandler _assertionFailureHandler = DefaultAssertionFailureHandler;
+
+        private static SdkMutexType InitMutex()
+        {
+            var mutex = new SdkMutexType();
+            mutex.Initialize();
+            return mutex;
+        }
+
+        private static AbortReason ToAbortReason(AssertionType assertionType)
+        {
+            switch (assertionType)
+            {
+                case AssertionType.SdkAssert: return AbortReason.SdkAssert;
+                case AssertionType.SdkRequires: return AbortReason.SdkRequires;
+                case AssertionType.UserAssert: return AbortReason.UserAssert;
+                default: return AbortReason.Abort;
+            }
+        }
+
+        private static AssertionFailureOperation DefaultAssertionFailureHandler(in AssertionInfo assertionInfo)
+        {
+            return AssertionFailureOperation.Abort;
+        }
+
+        private static void ExecuteAssertionFailureOperation(AssertionFailureOperation operation,
+            in AssertionInfo assertionInfo)
+        {
+            switch (operation)
+            {
+                case AssertionFailureOperation.Abort:
+                    var abortInfo = new AbortInfo
+                    {
+                        AbortReason = ToAbortReason(assertionInfo.AssertionType),
+                        Message = assertionInfo.Message,
+                        Condition = assertionInfo.Condition,
+                        FunctionName = assertionInfo.FunctionName,
+                        FileName = assertionInfo.FileName,
+                        LineNumber = assertionInfo.LineNumber
+                    };
+
+                    Abort.InvokeAbortObserver(in abortInfo);
+                    Abort.DoAbort(abortInfo.Message);
+                    break;
+                case AssertionFailureOperation.Continue:
+                    return;
+                default:
+                    Abort.DoAbort("Unknown AssertionFailureOperation");
+                    break;
+            }
+        }
+
+        private static void InvokeAssertionFailureHandler(in AssertionInfo assertionInfo)
+        {
+            AssertionFailureOperation operation = _assertionFailureHandler(in assertionInfo);
+            ExecuteAssertionFailureOperation(operation, in assertionInfo);
+        }
+
+        internal static void OnAssertionFailure(AssertionType assertionType, string condition, string functionName,
+            string fileName, int lineNumber)
+        {
+            OnAssertionFailure(assertionType, condition, functionName, fileName, lineNumber, string.Empty);
+        }
+
+        internal static void OnAssertionFailure(AssertionType assertionType, string condition, string functionName,
+            string fileName, int lineNumber, string message)
+        {
+            // Invalidate the IPC message buffer and call SynchronizePreemptionState if necessary
+            // nn::diag::detail::PrepareAbort();
+
+            if (_mutex.IsLockedByCurrentThread())
+                Abort.DoAbort();
+
+            using ScopedLock<SdkMutexType> lk = ScopedLock.Lock(ref _mutex);
+
+            var assertionInfo = new AssertionInfo
+            {
+                AssertionType = assertionType,
+                Message = message,
+                Condition = condition,
+                FunctionName = functionName,
+                FileName = fileName,
+                LineNumber = lineNumber
+            };
+
+            InvokeAssertionFailureHandler(in assertionInfo);
+        }
+
+        public static void SetAssertionFailureHandler(AssertionFailureHandler assertionHandler)
+        {
+            _assertionFailureHandler = assertionHandler;
+        }
+
+        // ---------------------------------------------------------------------
+        // True
+        // ---------------------------------------------------------------------
+
+        private static void TrueImpl(AssertionType assertionType, bool condition, string conditionText, string message,
+            string functionName, string fileName, int lineNumber)
         {
             if (condition)
                 return;
 
-            if (string.IsNullOrWhiteSpace(message))
-            {
-                throw new LibHacException("Assertion failed.");
-            }
-
-            throw new LibHacException($"Assertion failed: {message}");
+            OnAssertionFailure(assertionType, conditionText, functionName, fileName, lineNumber, message);
         }
 
-        [Conditional("DEBUG")]
-        public static void False([DoesNotReturnIf(true)] bool condition, string message = null)
+        [Conditional(AssertCondition)]
+        public static void True([DoesNotReturnIf(false)] bool condition,
+            string message = "",
+            [CallerArgumentExpression("condition")] string conditionText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
-            if (!condition)
+            TrueImpl(AssertionType.UserAssert, condition, conditionText, message, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void SdkAssert([DoesNotReturnIf(false)] bool condition,
+            string message = "",
+            [CallerArgumentExpression("condition")] string conditionText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            TrueImpl(AssertionType.SdkAssert, condition, conditionText, message, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void SdkRequires([DoesNotReturnIf(false)] bool condition,
+            string message = "",
+            [CallerArgumentExpression("condition")] string conditionText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            TrueImpl(AssertionType.SdkRequires, condition, conditionText, message, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not null
+        // ---------------------------------------------------------------------
+
+        private static void NotNullImpl<T>(AssertionType assertionType, [NotNull] T value, string valueText,
+            string functionName, string fileName, int lineNumber) where T : class
+        {
+            if (AssertImpl.NotNull(value))
                 return;
 
-            if (string.IsNullOrWhiteSpace(message))
-            {
-                throw new LibHacException("Assertion failed.");
-            }
-
-            throw new LibHacException($"Assertion failed: {message}");
+            AssertImpl.InvokeAssertionNotNull(assertionType, valueText, functionName, fileName, lineNumber);
         }
 
-        [Conditional("DEBUG")]
-        public static void Null<T>([NotNull] T item) where T : class
+        [Conditional(AssertCondition)]
+        public static void NotNull<T>([NotNull] T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : class
         {
-            if (!(item is null))
-            {
-                throw new LibHacException("Null assertion failed.");
-            }
+            NotNullImpl(AssertionType.UserAssert, value, valueText, functionName, fileName, lineNumber);
         }
 
-        [Conditional("DEBUG")]
-        public static void NotNull<T>([NotNull] T item) where T : class
+        [Conditional(AssertCondition)]
+        internal static void SdkNotNull<T>([NotNull] T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : class
         {
-            if (item is null)
-            {
-                throw new LibHacException("Not-null assertion failed.");
-            }
+            NotNullImpl(AssertionType.SdkAssert, value, valueText, functionName, fileName, lineNumber);
         }
 
-        [Conditional("DEBUG")]
-        public static void InRange(int value, int lowerInclusive, int upperExclusive)
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotNull<T>([NotNull] T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : class
         {
-            InRange((long)value, lowerInclusive, upperExclusive);
+            NotNullImpl(AssertionType.SdkRequires, value, valueText, functionName, fileName, lineNumber);
         }
 
-        [Conditional("DEBUG")]
-        public static void InRange(long value, long lowerInclusive, long upperExclusive)
+        // ---------------------------------------------------------------------
+        // Not null ref
+        // ---------------------------------------------------------------------
+
+        private static void NotNullImpl<T>(AssertionType assertionType, [NotNull] ref T value, string valueText,
+            string functionName, string fileName, int lineNumber)
         {
-            if (value < lowerInclusive || value >= upperExclusive)
-            {
-                throw new LibHacException($"Value {value} is not in the range {lowerInclusive} to {upperExclusive}");
-            }
+            if (AssertImpl.NotNull(ref value))
+                return;
+
+            AssertImpl.InvokeAssertionNotNull(assertionType, valueText, functionName, fileName, lineNumber);
         }
 
-        public static void Equal<T>(T value1, T value2) where T : IEquatable<T>
+        [Conditional(AssertCondition)]
+        public static void NotNull<T>([NotNull] ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
-            if (!value1.Equals(value2))
-            {
-                throw new LibHacException($"Values were not equal: {value1}, {value2}");
-            }
+            NotNullImpl(AssertionType.UserAssert, ref value, valueText, functionName, fileName, lineNumber);
         }
 
-        public static void NotEqual<T>(T value1, T value2) where T : IEquatable<T>
+        [Conditional(AssertCondition)]
+        internal static void SdkNotNull<T>([NotNull] ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
-            if (value1.Equals(value2))
-            {
-                throw new LibHacException($"Values should not be equal: {value1}, {value2}");
-            }
+            NotNullImpl(AssertionType.SdkAssert, ref value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotNull<T>([NotNull] ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.SdkRequires, ref value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not null out
+        // ---------------------------------------------------------------------
+
+        private static void NotNullOutImpl<T>(AssertionType assertionType, [NotNull] out T value, string valueText,
+            string functionName, string fileName, int lineNumber)
+        {
+            Unsafe.SkipInit(out value);
+
+#if ENABLE_ASSERTS
+            if (!Unsafe.IsNullRef(ref value))
+                return;
+
+            AssertImpl.InvokeAssertionNotNull(assertionType, valueText, functionName, fileName, lineNumber);
+#endif
+        }
+
+        public static void NotNullOut<T>([NotNull] out T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullOutImpl(AssertionType.UserAssert, out value, valueText, functionName, fileName, lineNumber);
+        }
+
+        internal static void SdkNotNullOut<T>([NotNull] out T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullOutImpl(AssertionType.SdkAssert, out value, valueText, functionName, fileName, lineNumber);
+        }
+
+        internal static void SdkRequiresNotNullOut<T>([NotNull] out T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullOutImpl(AssertionType.SdkRequires, out value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not null span
+        // ---------------------------------------------------------------------
+
+        private static void NotNullImpl<T>(AssertionType assertionType, [NotNull] Span<T> value,
+            string valueText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.NotNull(value))
+                return;
+
+            AssertImpl.InvokeAssertionNotNull(assertionType, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void NotNull<T>([NotNull] Span<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.UserAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNotNull<T>([NotNull] Span<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.SdkAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotNull<T>([NotNull] Span<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.SdkRequires, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not null read-only span
+        // ---------------------------------------------------------------------
+
+        private static void NotNullImpl<T>(AssertionType assertionType, [NotNull] ReadOnlySpan<T> value,
+            string valueText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.NotNull(value))
+                return;
+
+            AssertImpl.InvokeAssertionNotNull(assertionType, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void NotNull<T>([NotNull] ReadOnlySpan<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.UserAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNotNull<T>([NotNull] ReadOnlySpan<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.SdkAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotNull<T>([NotNull] ReadOnlySpan<T> value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NotNullImpl(AssertionType.SdkRequires, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Null
+        // ---------------------------------------------------------------------
+
+        private static void NullImpl<T>(AssertionType assertionType, T value, string valueText,
+            string functionName, string fileName, int lineNumber) where T : class
+        {
+            if (AssertImpl.Null(value))
+                return;
+
+            AssertImpl.InvokeAssertionNull(assertionType, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Null<T>(T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber]
+            int lineNumber = 0)
+            where T : class
+        {
+            NullImpl(AssertionType.UserAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNull<T>(T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : class
+        {
+            NullImpl(AssertionType.SdkAssert, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNull<T>(T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : class
+        {
+            NullImpl(AssertionType.SdkRequires, value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Null ref
+        // ---------------------------------------------------------------------
+
+        private static void NullImpl<T>(AssertionType assertionType, ref T value, string valueText,
+            string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.Null(ref value))
+                return;
+
+            AssertImpl.InvokeAssertionNull(assertionType, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Null<T>(ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NullImpl(AssertionType.UserAssert, ref value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNull<T>(ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NullImpl(AssertionType.SdkAssert, ref value, valueText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNull<T>(ref T value,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            NullImpl(AssertionType.SdkRequires, ref value, valueText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // In range
+        // ---------------------------------------------------------------------
+
+        private static void InRangeImpl(AssertionType assertionType, int value, int lower, int upper, string valueText,
+            string lowerText, string upperText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.WithinRange(value, lower, upper))
+                return;
+
+            AssertImpl.InvokeAssertionInRange(assertionType, value, lower, upper, valueText, lowerText, upperText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void InRange(int value, int lowerInclusive, int upperExclusive,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("lowerInclusive")] string lowerInclusiveText = "",
+            [CallerArgumentExpression("upperExclusive")] string upperExclusiveText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            InRangeImpl(AssertionType.UserAssert, value, lowerInclusive, upperExclusive, valueText, lowerInclusiveText,
+                upperExclusiveText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkInRange(int value, int lowerInclusive, int upperExclusive,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("lowerInclusive")] string lowerInclusiveText = "",
+            [CallerArgumentExpression("upperExclusive")] string upperExclusiveText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            InRangeImpl(AssertionType.SdkAssert, value, lowerInclusive, upperExclusive, valueText, lowerInclusiveText,
+                upperExclusiveText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresInRange(int value, int lowerInclusive, int upperExclusive,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("lowerInclusive")] string lowerInclusiveText = "",
+            [CallerArgumentExpression("upperExclusive")] string upperExclusiveText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            InRangeImpl(AssertionType.SdkRequires, value, lowerInclusive, upperExclusive, valueText, lowerInclusiveText,
+                upperExclusiveText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Within min-max int
+        // ---------------------------------------------------------------------
+
+        private static void WithinMinMaxImpl(AssertionType assertionType, int value, int min, int max, string valueText,
+            string minText, string maxText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.WithinMinMax(value, min, max))
+                return;
+
+            AssertImpl.InvokeAssertionWithinMinMax(assertionType, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void WithinMinMax(int value, int min, int max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.UserAssert, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkWithinMinMax(int value, int min, int max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.SdkAssert, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresWithinMinMax(int value, int min, int max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.SdkRequires, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Within min-max long
+        // ---------------------------------------------------------------------
+
+        private static void WithinMinMaxImpl(AssertionType assertionType, long value, long min, long max,
+            string valueText, string minText, string maxText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.WithinMinMax(value, min, max))
+                return;
+
+            AssertImpl.InvokeAssertionWithinMinMax(assertionType, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void WithinMinMax(long value, long min, long max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.UserAssert, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkWithinMinMax(long value, long min, long max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.SdkAssert, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresWithinMinMax(long value, long min, long max,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("min")] string minText = "",
+            [CallerArgumentExpression("max")] string maxText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            WithinMinMaxImpl(AssertionType.SdkRequires, value, min, max, valueText, minText, maxText, functionName,
+                fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Equal
+        // ---------------------------------------------------------------------
+
+        private static void EqualImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText, string rhsText,
+            string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            if (AssertImpl.Equal(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Equal<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Equal ref
+        // ---------------------------------------------------------------------
+
+        private static void EqualImpl<T>(AssertionType assertionType, ref T lhs, ref T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            if (AssertImpl.Equal(ref lhs, ref rhs))
+                return;
+
+            AssertImpl.InvokeAssertionEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Equal<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.UserAssert, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkEqual<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.SdkAssert, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresEqual<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            EqualImpl(AssertionType.SdkRequires, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName,
+                lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not equal
+        // ---------------------------------------------------------------------
+
+        private static void NotEqualImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText, string rhsText,
+            string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            if (AssertImpl.NotEqual(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionNotEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void NotEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNotEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Not equal ref
+        // ---------------------------------------------------------------------
+
+        private static void NotEqualImpl<T>(AssertionType assertionType, ref T lhs, ref T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            if (AssertImpl.NotEqual(ref lhs, ref rhs))
+                return;
+
+            AssertImpl.InvokeAssertionNotEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void NotEqual<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.UserAssert, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName,
+                lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkNotEqual<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.SdkAssert, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName,
+                lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresNotEqual<T>(ref T lhs, ref T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IEquatable<T>
+        {
+            NotEqualImpl(AssertionType.SdkRequires, ref lhs, ref rhs, lhsText, rhsText, functionName, fileName,
+                lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Less
+        // ---------------------------------------------------------------------
+
+        private static void LessImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText, string rhsText,
+            string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            if (AssertImpl.Less(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionLess(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Less<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkLess<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresLess<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Less equal
+        // ---------------------------------------------------------------------
+
+        private static void LessEqualImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText, string rhsText,
+            string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            if (AssertImpl.LessEqual(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionLessEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void LessEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessEqualImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkLessEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessEqualImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresLessEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            LessEqualImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Greater
+        // ---------------------------------------------------------------------
+
+        private static void GreaterImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText, string rhsText,
+            string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            if (AssertImpl.Greater(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionGreater(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Greater<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkGreater<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresGreater<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Greater equal
+        // ---------------------------------------------------------------------
+
+        private static void GreaterEqualImpl<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            if (AssertImpl.GreaterEqual(lhs, rhs))
+                return;
+
+            AssertImpl.InvokeAssertionGreaterEqual(assertionType, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void GreaterEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterEqualImpl(AssertionType.UserAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkGreaterEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterEqualImpl(AssertionType.SdkAssert, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresGreaterEqual<T>(T lhs, T rhs,
+            [CallerArgumentExpression("lhs")] string lhsText = "",
+            [CallerArgumentExpression("rhs")] string rhsText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+            where T : IComparable<T>
+        {
+            GreaterEqualImpl(AssertionType.SdkRequires, lhs, rhs, lhsText, rhsText, functionName, fileName, lineNumber);
+        }
+
+        // ---------------------------------------------------------------------
+        // Aligned
+        // ---------------------------------------------------------------------
+
+        private static void AlignedImpl(AssertionType assertionType, ulong value, int alignment, string valueText,
+            string alignmentText, string functionName, string fileName, int lineNumber)
+        {
+            if (AssertImpl.IsAligned(value, alignment))
+                return;
+
+            AssertImpl.InvokeAssertionAligned(assertionType, value, alignment, valueText, alignmentText, functionName, fileName,
+                lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        public static void Aligned(ulong value, int alignment,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("alignment")] string alignmentText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            AlignedImpl(AssertionType.UserAssert, value, alignment, valueText, alignmentText, functionName, fileName,
+                lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkAligned(ulong value, int alignment,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("alignment")] string alignmentText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            AlignedImpl(AssertionType.SdkAssert, value, alignment, valueText, alignmentText, functionName, fileName,
+                lineNumber);
+        }
+
+        [Conditional(AssertCondition)]
+        internal static void SdkRequiresAligned(ulong value, int alignment,
+            [CallerArgumentExpression("value")] string valueText = "",
+            [CallerArgumentExpression("alignment")] string alignmentText = "",
+            [CallerMemberName] string functionName = "",
+            [CallerFilePath] string fileName = "",
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            AlignedImpl(AssertionType.SdkRequires, value, alignment, valueText, alignmentText, functionName, fileName,
+                lineNumber);
         }
     }
 }

--- a/src/LibHac/Diag/Impl/AssertImpl.cs
+++ b/src/LibHac/Diag/Impl/AssertImpl.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using LibHac.Util;
+
+namespace LibHac.Diag.Impl
+{
+    internal static class AssertImpl
+    {
+        internal static void InvokeAssertionNotNull(AssertionType assertionType, string valueText, string functionName,
+            string fileName, int lineNumber)
+        {
+            Assert.OnAssertionFailure(assertionType, valueText, functionName, fileName, lineNumber,
+                $"{valueText} must not be nullptr.");
+        }
+
+        internal static void InvokeAssertionNull(AssertionType assertionType, string valueText, string functionName,
+            string fileName, int lineNumber)
+        {
+            Assert.OnAssertionFailure(assertionType, valueText, functionName, fileName, lineNumber,
+                $"{valueText} must be nullptr.");
+        }
+
+        internal static void InvokeAssertionInRange(AssertionType assertionType, int value, int lower, int upper,
+            string valueText, string lowerText, string upperText, string functionName, string fileName, int lineNumber)
+        {
+            string message =
+                string.Format(
+                    "{0} must be within the range [{1}, {2})\nThe actual values are as follows.\n{0}: {3}\n{1}: {4}\n{2}: {5}",
+                    valueText, lowerText, upperText, value, lower, upper);
+
+            Assert.OnAssertionFailure(assertionType, "RangeCheck", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionWithinMinMax(AssertionType assertionType, long value, long min, long max,
+            string valueText, string minText, string maxText, string functionName, string fileName, int lineNumber)
+        {
+            string message =
+                string.Format(
+                    "{0} must satisfy the condition min:{1} and max:{2}\nThe actual values are as follows.\n{0}: {3}\n{1}: {4}\n{2}: {5}",
+                    valueText, minText, maxText, value, min, max);
+
+            Assert.OnAssertionFailure(assertionType, "MinMaxCheck", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionEqual<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            string message =
+                string.Format("{0} must be equal to {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "Equal", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionNotEqual<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IEquatable<T>
+        {
+            string message =
+                string.Format("{0} must be equal to {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "Equal", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionLess<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            string message =
+                string.Format("{0} must be less than {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "Less", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionLessEqual<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            string message =
+                string.Format(
+                    "{0} must be less than or equal to {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "LessEqual", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionGreater<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            string message =
+                string.Format("{0} must be greater than {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "Greater", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionGreaterEqual<T>(AssertionType assertionType, T lhs, T rhs, string lhsText,
+            string rhsText, string functionName, string fileName, int lineNumber) where T : IComparable<T>
+        {
+            string message =
+                string.Format(
+                    "{0} must be greater than or equal to {1}.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    lhsText, rhsText, lhs, rhs);
+
+            Assert.OnAssertionFailure(assertionType, "GreaterEqual", functionName, fileName, lineNumber, message);
+        }
+
+        internal static void InvokeAssertionAligned(AssertionType assertionType, ulong value, int alignment,
+            string valueText, string alignmentText, string functionName, string fileName, int lineNumber)
+        {
+            string message =
+                string.Format("{0} must be {1}-bytes aligned.\nThe actual values are as follows.\n{0}: {2}\n{1}: {3}",
+                    valueText, alignmentText, value, alignment);
+
+            Assert.OnAssertionFailure(assertionType, "Aligned", functionName, fileName, lineNumber, message);
+        }
+
+        public static bool Null<T>(T item) where T : class
+        {
+            return item is null;
+        }
+
+        public static bool Null<T>(ref T item)
+        {
+            return Unsafe.IsNullRef(ref item);
+        }
+
+        public static bool NotNull<T>(T item) where T : class
+        {
+            return item is not null;
+        }
+
+        public static bool NotNull<T>(ref T item)
+        {
+            return !Unsafe.IsNullRef(ref item);
+        }
+
+        public static bool NotNull<T>(Span<T> span)
+        {
+            return !Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
+        }
+
+        public static bool NotNull<T>(ReadOnlySpan<T> span)
+        {
+            return !Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
+        }
+
+        public static bool WithinRange(int value, int lowerInclusive, int upperExclusive)
+        {
+            return lowerInclusive <= value && value < upperExclusive;
+        }
+
+        public static bool WithinRange(long value, long lowerInclusive, long upperExclusive)
+        {
+            return lowerInclusive <= value && value < upperExclusive;
+        }
+
+        public static bool WithinMinMax(int value, int min, int max)
+        {
+            return min <= value && value <= max;
+        }
+
+        public static bool WithinMinMax(long value, long min, long max)
+        {
+            return min <= value && value <= max;
+        }
+
+        public static bool Equal<T>(T lhs, T rhs) where T : IEquatable<T>
+        {
+            return lhs.Equals(rhs);
+        }
+
+        public static bool Equal<T>(ref T lhs, ref T rhs) where T : IEquatable<T>
+        {
+            return lhs.Equals(rhs);
+        }
+
+        public static bool NotEqual<T>(T lhs, T rhs) where T : IEquatable<T>
+        {
+            return !lhs.Equals(rhs);
+        }
+
+        public static bool NotEqual<T>(ref T lhs, ref T rhs) where T : IEquatable<T>
+        {
+            return !lhs.Equals(rhs);
+        }
+
+        public static bool Less<T>(T lhs, T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) < 0;
+        }
+
+        public static bool Less<T>(ref T lhs, ref T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) < 0;
+        }
+
+        public static bool LessEqual<T>(T lhs, T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) <= 0;
+        }
+
+        public static bool LessEqual<T>(ref T lhs, ref T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) <= 0;
+        }
+
+        public static bool Greater<T>(T lhs, T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) > 0;
+        }
+
+        public static bool Greater<T>(ref T lhs, ref T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) > 0;
+        }
+
+        public static bool GreaterEqual<T>(T lhs, T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) >= 0;
+        }
+
+        public static bool GreaterEqual<T>(ref T lhs, ref T rhs) where T : IComparable<T>
+        {
+            return lhs.CompareTo(rhs) >= 0;
+        }
+
+        public static bool IsAligned(ulong value, int alignment)
+        {
+            return Alignment.IsAlignedPow2(value, (uint)alignment);
+        }
+    }
+}

--- a/src/LibHac/Diag/Impl/ObserverManager.cs
+++ b/src/LibHac/Diag/Impl/ObserverManager.cs
@@ -23,7 +23,7 @@ namespace LibHac.Diag.Impl
 
         public void RegisterObserver(TObserver observerHolder)
         {
-            Assert.False(observerHolder.IsRegistered);
+            Assert.SdkRequires(!observerHolder.IsRegistered);
 
             using ScopedLock<ReaderWriterLock> lk = ScopedLock.Lock(ref _rwLock);
 
@@ -33,7 +33,7 @@ namespace LibHac.Diag.Impl
 
         public void UnregisterObserver(TObserver observerHolder)
         {
-            Assert.True(observerHolder.IsRegistered);
+            Assert.SdkRequires(observerHolder.IsRegistered);
 
             using ScopedLock<ReaderWriterLock> lk = ScopedLock.Lock(ref _rwLock);
 
@@ -91,7 +91,7 @@ namespace LibHac.Diag.Impl
 
         public void RegisterObserver(LogObserverHolder observerHolder)
         {
-            Assert.False(observerHolder.IsRegistered);
+            Assert.SdkRequires(!observerHolder.IsRegistered);
 
             using ScopedLock<ReaderWriterLock> lk = ScopedLock.Lock(ref _rwLock);
 
@@ -101,7 +101,7 @@ namespace LibHac.Diag.Impl
 
         public void UnregisterObserver(LogObserverHolder observerHolder)
         {
-            Assert.True(observerHolder.IsRegistered);
+            Assert.SdkRequires(observerHolder.IsRegistered);
 
             using ScopedLock<ReaderWriterLock> lk = ScopedLock.Lock(ref _rwLock);
 

--- a/src/LibHac/Fs/AccessLog.cs
+++ b/src/LibHac/Fs/AccessLog.cs
@@ -139,7 +139,8 @@ namespace LibHac.Fs.Impl
         private ReadOnlySpan<byte> ToValueString(int value)
         {
             bool success = Utf8Formatter.TryFormat(value, _buffer.Bytes, out int length);
-            Assert.True(success && length < _buffer.Bytes.Length);
+            Assert.SdkAssert(success);
+            Assert.SdkLess(length, _buffer.Bytes.Length);
             _buffer[length] = 0;
 
             return _buffer.Bytes;
@@ -480,13 +481,13 @@ namespace LibHac.Fs.Impl
 
             public void RegisterCallback(AccessLogPrinterCallback callback)
             {
-                Assert.Null(_callback);
+                Assert.SdkNull(_callback);
                 _callback = callback;
             }
 
             public int InvokeCallback(Span<byte> textBuffer)
             {
-                Assert.True(IsRegisteredCallback());
+                Assert.SdkAssert(IsRegisteredCallback());
                 return _callback(textBuffer);
             }
         }
@@ -658,7 +659,8 @@ namespace LibHac.Fs.Impl
 
             // We should never receive non-null here.
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            Assert.True(handle is null);
+            Assert.SdkAssert(handle is null,
+                "Handle type must be FileHandle or DirectoryHandle. Please cast to handle type.");
             return false;
         }
 
@@ -683,7 +685,7 @@ namespace LibHac.Fs.Impl
 
         internal static void FlushAccessLog(this FileSystemClientImpl fs)
         {
-            Assert.True(false, $"Unsupported {nameof(FlushAccessLog)}");
+            Assert.SdkAssert(false, $"Unsupported {nameof(FlushAccessLog)}");
         }
 
         internal static void FlushAccessLogOnSdCard(this FileSystemClientImpl fs)

--- a/src/LibHac/Fs/Fsa/IFile.cs
+++ b/src/LibHac/Fs/Fsa/IFile.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using LibHac.Common;
-using LibHac.Diag;
 
 namespace LibHac.Fs.Fsa
 {
@@ -180,8 +179,6 @@ namespace LibHac.Fs.Fsa
             // Check that we can write.
             if (!openMode.HasFlag(OpenMode.Write))
                 return ResultFs.WriteUnpermitted.Log();
-
-            Assert.True(size >= 0);
 
             return Result.Success;
         }

--- a/src/LibHac/Fs/Fsa/MountTable.cs
+++ b/src/LibHac/Fs/Fsa/MountTable.cs
@@ -68,7 +68,7 @@ namespace LibHac.Fs.Impl
 
         public bool CanAcceptMountName(U8Span name)
         {
-            Assert.True(_mutex.IsLockedByCurrentThread());
+            Assert.SdkAssert(_mutex.IsLockedByCurrentThread());
 
             for (LinkedListNode<FileSystemAccessor> currentNode = _fileSystemList.First;
                 currentNode is not null;

--- a/src/LibHac/Fs/Impl/IFileDataCache.cs
+++ b/src/LibHac/Fs/Impl/IFileDataCache.cs
@@ -55,7 +55,7 @@ namespace LibHac.Fs.Impl
 
         public int GetCacheFetchedRegionCount()
         {
-            Assert.True(_isFileDataCacheUsed);
+            Assert.SdkRequires(_isFileDataCacheUsed);
             return _regionCount;
         }
 
@@ -63,9 +63,9 @@ namespace LibHac.Fs.Impl
 
         public FileRegion GetCacheFetchedRegion(int index)
         {
-            Assert.True(IsFileDataCacheUsed());
-            Assert.True(index >= 0);
-            Assert.True(index < _regionCount);
+            Assert.SdkRequires(IsFileDataCacheUsed());
+            Assert.SdkRequiresLessEqual(0, index);
+            Assert.SdkRequiresLess(index, _regionCount);
 
             return _regions[index];
         }

--- a/src/LibHac/Fs/Shim/ContentStorage.cs
+++ b/src/LibHac/Fs/Shim/ContentStorage.cs
@@ -32,14 +32,14 @@ namespace LibHac.Fs.Shim
                 int neededSize =
                     StringUtils.GetLength(GetContentStorageMountName(StorageId), PathTool.MountNameLengthMax) + 2;
 
-                Assert.True(nameBuffer.Length >= neededSize);
+                Assert.SdkRequiresGreaterEqual(nameBuffer.Length, neededSize);
 
                 // Generate the name.
                 var sb = new U8StringBuilder(nameBuffer);
                 sb.Append(GetContentStorageMountName(StorageId))
                     .Append(StringTraits.DriveSeparator);
 
-                Assert.True(sb.Length == neededSize - 1);
+                Assert.SdkEqual(sb.Length, neededSize - 1);
 
                 return Result.Success;
             }

--- a/src/LibHac/Fs/Shim/GameCard.cs
+++ b/src/LibHac/Fs/Shim/GameCard.cs
@@ -53,7 +53,7 @@ namespace LibHac.Fs.Shim
                     StringUtils.GetLength(GetGameCardMountNameSuffix(PartitionId), PathTool.MountNameLengthMax) +
                     handleDigitCount + 2;
 
-                Assert.True(nameBuffer.Length >= neededSize);
+                Assert.SdkRequiresGreaterEqual(nameBuffer.Length, neededSize);
 
                 // Generate the name.
                 var sb = new U8StringBuilder(nameBuffer);
@@ -62,7 +62,7 @@ namespace LibHac.Fs.Shim
                     .AppendFormat(Handle.Value, 'x', (byte)handleDigitCount)
                     .Append(StringTraits.DriveSeparator);
 
-                Assert.True(sb.Length == neededSize - 1);
+                Assert.SdkEqual(sb.Length, neededSize - 1);
 
                 return Result.Success;
             }

--- a/src/LibHac/Fs/Shim/Host.cs
+++ b/src/LibHac/Fs/Shim/Host.cs
@@ -93,7 +93,7 @@ namespace LibHac.Fs.Shim
                 var sb = new U8StringBuilder(nameBuffer);
                 sb.Append(HostRootFileSystemPath).Append(_path.Str);
 
-                Assert.True(sb.Length == requiredNameBufferSize - 1);
+                Assert.SdkEqual(sb.Length, requiredNameBufferSize - 1);
 
                 return Result.Success;
             }
@@ -107,12 +107,12 @@ namespace LibHac.Fs.Shim
             {
                 const int requiredNameBufferSize = HostRootFileSystemPathLength;
 
-                Assert.True(nameBuffer.Length >= requiredNameBufferSize);
+                Assert.SdkRequiresGreaterEqual(nameBuffer.Length, requiredNameBufferSize);
 
                 var sb = new U8StringBuilder(nameBuffer);
                 sb.Append(HostRootFileSystemPath);
 
-                Assert.True(sb.Length == requiredNameBufferSize - 1);
+                Assert.SdkEqual(sb.Length, requiredNameBufferSize - 1);
 
                 return Result.Success;
             }

--- a/src/LibHac/Fs/SubStorage.cs
+++ b/src/LibHac/Fs/SubStorage.cs
@@ -82,9 +82,9 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.True(IsValid());
-            Assert.True(Offset >= 0);
-            Assert.True(Size >= 0);
+            Assert.SdkRequiresNotNull(baseStorage);
+            Assert.SdkRequiresLessEqual(0, Offset);
+            Assert.SdkRequiresLessEqual(0, Size);
         }
 
         /// <summary>
@@ -102,9 +102,9 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.True(IsValid());
-            Assert.True(Offset >= 0);
-            Assert.True(Size >= 0);
+            Assert.SdkRequiresNotNull(sharedBaseStorage);
+            Assert.SdkRequiresLessEqual(0, Offset);
+            Assert.SdkRequiresLessEqual(0, Size);
         }
 
         /// <summary>
@@ -126,10 +126,10 @@ namespace LibHac.Fs
             Size = size;
             IsResizable = false;
 
-            Assert.True(IsValid());
-            Assert.True(Offset >= 0);
-            Assert.True(Size >= 0);
-            Assert.True(other.Size >= offset + size);
+            Assert.SdkRequires(other.IsValid());
+            Assert.SdkRequiresLessEqual(0, Offset);
+            Assert.SdkRequiresLessEqual(0, Size);
+            Assert.SdkRequiresGreaterEqual(other.Size, offset + size);
         }
 
         private bool IsValid() => BaseStorage != null;

--- a/src/LibHac/FsSrv/Impl/LocationResolverSet.cs
+++ b/src/LibHac/FsSrv/Impl/LocationResolverSet.cs
@@ -197,7 +197,7 @@ namespace LibHac.FsSrv.Impl
 
         private static int GetResolverIndexFromStorageId(StorageId id)
         {
-            Assert.True(IsValidStorageId(id));
+            Assert.SdkRequires(IsValidStorageId(id));
 
             return id switch
             {

--- a/src/LibHac/FsSrv/Impl/Utility.cs
+++ b/src/LibHac/FsSrv/Impl/Utility.cs
@@ -36,7 +36,7 @@ namespace LibHac.FsSrv.Impl
         private static Result EnsureDirectoryImpl(IFileSystem fileSystem, Span<byte> path)
         {
             // Double check the trailing separators have been trimmed
-            Assert.True(path.Length <= 1 || path[path.Length - 1] != StringTraits.DirectorySeparator);
+            Assert.SdkRequires(path.Length <= 1 || path[path.Length - 1] != StringTraits.DirectorySeparator);
 
             // Use the root path if the input path is empty
             var pathToCheck = new U8Span(path.IsEmpty ? FileSystemRootPath : path);
@@ -91,8 +91,8 @@ namespace LibHac.FsSrv.Impl
         private static Result EnsureParentDirectoryImpl(IFileSystem fileSystem, Span<byte> path)
         {
             // The path should not be empty or have a trailing directory separator
-            Assert.True(path.Length > 0);
-            Assert.NotEqual(StringTraits.DirectorySeparator, path[path.Length - 1]);
+            Assert.SdkRequiresLess(0, path.Length);
+            Assert.SdkRequiresNotEqual(path[path.Length - 1], StringTraits.DirectorySeparator);
 
             // Make sure the path's not too long
             if (path.Length > PathTool.EntryNameLengthMax)

--- a/src/LibHac/FsSrv/NcaFileSystemService.cs
+++ b/src/LibHac/FsSrv/NcaFileSystemService.cs
@@ -121,7 +121,7 @@ namespace LibHac.FsSrv
                     if (originalResult.IsFailure())
                         return originalResult;
 
-                    Assert.True(originalPathNormalizerHasValue);
+                    Assert.SdkAssert(originalPathNormalizerHasValue);
 
                     // There is an original version and no patch version. Open the original directly
                     rc = ServiceImpl.OpenFileSystem(out tempFileSystem, originalPathNormalizer.Path, fsType, programId.Value);

--- a/src/LibHac/FsSrv/SaveDataIndexer.cs
+++ b/src/LibHac/FsSrv/SaveDataIndexer.cs
@@ -533,7 +533,7 @@ namespace LibHac.FsSrv
 
         private FlatMapKeyValueStore<SaveDataAttribute>.Iterator GetBeginIterator()
         {
-            Assert.True(IsKvdbLoaded);
+            Assert.SdkRequires(IsKvdbLoaded);
 
             return KvDatabase.GetBeginIterator();
         }

--- a/src/LibHac/FsSrv/SaveDataIndexerManager.cs
+++ b/src/LibHac/FsSrv/SaveDataIndexerManager.cs
@@ -168,7 +168,7 @@ namespace LibHac.FsSrv
 
             // ReSharper disable once RedundantAssignment
             Result rc = _tempIndexer.Indexer.Reset();
-            Assert.True(rc.IsSuccess());
+            Assert.SdkAssert(rc.IsSuccess());
         }
 
         public void InvalidateIndexer(SaveDataSpaceId spaceId)

--- a/src/LibHac/FsSrv/Sf/Path.cs
+++ b/src/LibHac/FsSrv/Sf/Path.cs
@@ -1,8 +1,11 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using LibHac.Common;
 using LibHac.Fs;
+
+#if DEBUG
+using System.Diagnostics;
+#endif
 
 namespace LibHac.FsSrv.Sf
 {

--- a/src/LibHac/FsSrv/StatusReportService.cs
+++ b/src/LibHac/FsSrv/StatusReportService.cs
@@ -124,15 +124,15 @@ namespace LibHac.FsSrv
             switch (threadType)
             {
                 case FsStackUsageThreadType.MainThread:
-                    Assert.NotNull(_config.MainThreadStackUsageReporter);
+                    Assert.SdkRequiresNotNull(_config.MainThreadStackUsageReporter);
                     return _config.MainThreadStackUsageReporter.GetStackUsage();
 
                 case FsStackUsageThreadType.IpcWorker:
-                    Assert.NotNull(_config.IpcWorkerThreadStackUsageReporter);
+                    Assert.SdkRequiresNotNull(_config.IpcWorkerThreadStackUsageReporter);
                     return _config.IpcWorkerThreadStackUsageReporter.GetStackUsage();
 
                 case FsStackUsageThreadType.PipelineWorker:
-                    Assert.NotNull(_config.PipeLineWorkerThreadStackUsageReporter);
+                    Assert.SdkRequiresNotNull(_config.PipeLineWorkerThreadStackUsageReporter);
                     return _config.PipeLineWorkerThreadStackUsageReporter.GetStackUsage();
 
                 default:

--- a/src/LibHac/FsSrv/Storage/StorageDeviceManagerFactory.cs
+++ b/src/LibHac/FsSrv/Storage/StorageDeviceManagerFactory.cs
@@ -31,7 +31,7 @@ namespace LibHac.FsSrv.Storage
             out ReferenceCountedDisposable<IStorageDeviceManager> deviceManager, StorageDevicePortId portId)
         {
             IStorageDeviceManagerFactory factory = storage.GetStorageDeviceManagerFactory(null);
-            Assert.NotNull(factory);
+            Assert.SdkNotNull(factory);
 
             return factory.Create(out deviceManager, portId);
         }

--- a/src/LibHac/FsSystem/BucketTree.cs
+++ b/src/LibHac/FsSystem/BucketTree.cs
@@ -35,11 +35,11 @@ namespace LibHac.FsSystem
         public Result Initialize(SubStorage nodeStorage, SubStorage entryStorage, int nodeSize, int entrySize,
             int entryCount)
         {
-            Assert.True(entrySize >= sizeof(long));
-            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.True(!IsInitialized());
+            Assert.SdkRequiresLessEqual(sizeof(long), entrySize);
+            Assert.SdkRequiresLessEqual(entrySize + Unsafe.SizeOf<NodeHeader>(), nodeSize);
+            Assert.SdkRequiresWithinMinMax(nodeSize, NodeSizeMin, NodeSizeMax);
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.SdkRequires(!IsInitialized());
 
             // Ensure valid entry count.
             if (entryCount <= 0)
@@ -119,7 +119,7 @@ namespace LibHac.FsSystem
 
         public Result Find(ref Visitor visitor, long virtualAddress)
         {
-            Assert.True(IsInitialized());
+            Assert.SdkRequires(IsInitialized());
 
             if (virtualAddress < 0)
                 return ResultFs.InvalidOffset.Log();
@@ -137,11 +137,11 @@ namespace LibHac.FsSystem
 
         public static long QueryNodeStorageSize(long nodeSize, long entrySize, int entryCount)
         {
-            Assert.True(entrySize >= sizeof(long));
-            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.True(entryCount >= 0);
+            Assert.SdkRequiresLessEqual(sizeof(long), entrySize);
+            Assert.SdkRequiresLessEqual(entrySize + Unsafe.SizeOf<NodeHeader>(), nodeSize);
+            Assert.SdkRequiresWithinMinMax(nodeSize, NodeSizeMin, NodeSizeMax);
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.SdkRequiresLessEqual(0, entryCount);
 
             if (entryCount <= 0)
                 return 0;
@@ -151,11 +151,11 @@ namespace LibHac.FsSystem
 
         public static long QueryEntryStorageSize(long nodeSize, long entrySize, int entryCount)
         {
-            Assert.True(entrySize >= sizeof(long));
-            Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-            Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-            Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
-            Assert.True(entryCount >= 0);
+            Assert.SdkRequiresLessEqual(sizeof(long), entrySize);
+            Assert.SdkRequiresLessEqual(entrySize + Unsafe.SizeOf<NodeHeader>(), nodeSize);
+            Assert.SdkRequiresWithinMinMax(nodeSize, NodeSizeMin, NodeSizeMax);
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(nodeSize));
+            Assert.SdkRequiresLessEqual(0, entryCount);
 
             if (entryCount <= 0)
                 return 0;
@@ -276,7 +276,7 @@ namespace LibHac.FsSystem
 
             public bool Allocate(int nodeSize)
             {
-                Assert.True(_header == null);
+                Assert.SdkRequiresNotNull(_header);
 
                 _header = new long[nodeSize / sizeof(long)];
 
@@ -298,7 +298,7 @@ namespace LibHac.FsSystem
 
             public ref NodeHeader GetHeader()
             {
-                Assert.True(_header.Length / sizeof(long) >= Unsafe.SizeOf<NodeHeader>());
+                Assert.SdkRequiresGreaterEqual(_header.Length / sizeof(long), Unsafe.SizeOf<NodeHeader>());
 
                 return ref Unsafe.As<long, NodeHeader>(ref _header[0]);
             }
@@ -322,8 +322,9 @@ namespace LibHac.FsSystem
             {
                 _buffer = buffer;
 
-                Assert.True(_buffer.Length >= Unsafe.SizeOf<NodeHeader>());
-                Assert.True(_buffer.Length >= Unsafe.SizeOf<NodeHeader>() + GetHeader().Count * Unsafe.SizeOf<TEntry>());
+                Assert.SdkRequiresGreaterEqual(_buffer.Length, Unsafe.SizeOf<NodeHeader>());
+                Assert.SdkRequiresGreaterEqual(_buffer.Length,
+                    Unsafe.SizeOf<NodeHeader>() + GetHeader().Count * Unsafe.SizeOf<TEntry>());
             }
 
             public int GetCount() => GetHeader().Count;
@@ -381,8 +382,8 @@ namespace LibHac.FsSystem
 
             public Result Initialize(BucketTree tree)
             {
-                Assert.True(tree != null);
-                Assert.True(Tree == null || tree == Tree);
+                Assert.SdkRequiresNotNull(tree);
+                Assert.SdkRequires(Tree == null || tree == Tree);
 
                 if (Entry == null)
                 {

--- a/src/LibHac/FsSystem/BucketTreeBuilder.cs
+++ b/src/LibHac/FsSystem/BucketTreeBuilder.cs
@@ -42,10 +42,10 @@ namespace LibHac.FsSystem
             public Result Initialize(SubStorage headerStorage, SubStorage nodeStorage, SubStorage entryStorage,
                 int nodeSize, int entrySize, int entryCount)
             {
-                Assert.True(entrySize >= sizeof(long));
-                Assert.True(nodeSize >= entrySize + Unsafe.SizeOf<NodeHeader>());
-                Assert.True(NodeSizeMin <= nodeSize && nodeSize <= NodeSizeMax);
-                Assert.True(BitUtil.IsPowerOfTwo(nodeSize));
+                Assert.SdkRequiresLessEqual(sizeof(long), entrySize);
+                Assert.SdkRequiresLessEqual(entrySize + Unsafe.SizeOf<NodeHeader>(), nodeSize);
+                Assert.SdkRequiresWithinMinMax(nodeSize, NodeSizeMin, NodeSizeMax);
+                Assert.SdkRequires(BitUtil.IsPowerOfTwo(nodeSize));
 
                 if (headerStorage is null || nodeStorage is null || entryStorage is null)
                     return ResultFs.NullptrArgument.Log();
@@ -99,7 +99,7 @@ namespace LibHac.FsSystem
             /// <returns>The <see cref="Result"/> of the operation.</returns>
             public Result Add<T>(ref T entry) where T : unmanaged
             {
-                Assert.True(Unsafe.SizeOf<T>() == EntrySize);
+                Assert.SdkRequiresEqual(Unsafe.SizeOf<T>(), EntrySize);
 
                 if (CurrentEntryIndex >= EntryCount)
                     return ResultFs.OutOfRange.Log();

--- a/src/LibHac/FsSystem/Buffers/BufferManagerUtility.cs
+++ b/src/LibHac/FsSystem/Buffers/BufferManagerUtility.cs
@@ -94,8 +94,9 @@ namespace LibHac.FsSystem.Buffers
             int size, IBufferManager.BufferAttribute attribute, IsValidBufferFunction isValidBuffer,
             [CallerMemberName] string callerName = "")
         {
-            Assert.NotNull(bufferManager);
-            Assert.NotNull(callerName);
+            Assert.SdkNotNullOut(out outBuffer);
+            Assert.SdkNotNull(bufferManager);
+            Assert.SdkNotNull(callerName);
 
             // Clear the output.
             outBuffer = new Buffer();
@@ -135,7 +136,7 @@ namespace LibHac.FsSystem.Buffers
                 if (rc.IsFailure()) return rc;
             }
 
-            Assert.True(!tempBuffer.IsNull);
+            Assert.SdkAssert(!tempBuffer.IsNull);
             outBuffer = tempBuffer;
             return Result.Success;
         }

--- a/src/LibHac/FsSystem/FsPath.cs
+++ b/src/LibHac/FsSystem/FsPath.cs
@@ -25,7 +25,7 @@ namespace LibHac.FsSystem
 
         public static Result FromSpan(out FsPath fsPath, ReadOnlySpan<byte> path)
         {
-            Unsafe.SkipInit(out fsPath);
+            UnsafeHelpers.SkipParamInit(out fsPath);
 
             // Ensure null terminator even if the creation fails for safety
             fsPath.Str[MaxLength] = 0;

--- a/src/LibHac/FsSystem/IndirectStorage.cs
+++ b/src/LibHac/FsSystem/IndirectStorage.cs
@@ -71,22 +71,22 @@ namespace LibHac.FsSystem
 
         public void SetStorage(int index, SubStorage storage)
         {
-            Assert.InRange(index, 0, StorageCount);
+            Assert.SdkRequiresInRange(index, 0, StorageCount);
             DataStorage[index] = storage;
         }
 
         public void SetStorage(int index, IStorage storage, long offset, long size)
         {
-            Assert.InRange(index, 0, StorageCount);
+            Assert.SdkRequiresInRange(index, 0, StorageCount);
             DataStorage[index] = new SubStorage(storage, offset, size);
         }
 
         public Result GetEntryList(Span<Entry> entryBuffer, out int outputEntryCount, long offset, long size)
         {
             // Validate pre-conditions
-            Assert.True(offset >= 0);
-            Assert.True(size >= 0);
-            Assert.True(IsInitialized());
+            Assert.SdkRequiresLessEqual(0, offset);
+            Assert.SdkRequiresLessEqual(0, size);
+            Assert.SdkRequires(IsInitialized());
 
             // Clear the out count
             outputEntryCount = 0;
@@ -153,8 +153,8 @@ namespace LibHac.FsSystem
         protected override unsafe Result DoRead(long offset, Span<byte> destination)
         {
             // Validate pre-conditions
-            Assert.True(offset >= 0);
-            Assert.True(IsInitialized());
+            Assert.SdkRequiresLessEqual(0, offset);
+            Assert.SdkRequires(IsInitialized());
 
             // Succeed if there's nothing to read
             if (destination.Length == 0)
@@ -206,9 +206,9 @@ namespace LibHac.FsSystem
         private Result OperatePerEntry(long offset, long size, OperateFunc func)
         {
             // Validate preconditions
-            Assert.True(offset >= 0);
-            Assert.True(size >= 0);
-            Assert.True(IsInitialized());
+            Assert.SdkRequiresLessEqual(0, offset);
+            Assert.SdkRequiresLessEqual(0, size);
+            Assert.SdkRequires(IsInitialized());
 
             // Succeed if there's nothing to operate on
             if (size == 0)
@@ -272,12 +272,12 @@ namespace LibHac.FsSystem
                     // Get the offset of the entry in the data we read
                     long dataOffset = currentOffset - currentEntryOffset;
                     long dataSize = nextEntryOffset - currentEntryOffset - dataOffset;
-                    Assert.True(dataSize > 0);
+                    Assert.SdkLess(0, dataSize);
 
                     // Determine how much is left
                     long remainingSize = endOffset - currentOffset;
                     long currentSize = Math.Min(remainingSize, dataSize);
-                    Assert.True(currentSize <= size);
+                    Assert.SdkLessEqual(currentSize, size);
 
                     {
                         SubStorage currentStorage = DataStorage[currentEntry.StorageIndex];

--- a/src/LibHac/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/FsSystem/NcaUtils/Nca.cs
@@ -659,7 +659,7 @@ namespace LibHac.FsSystem.NcaUtils
         {
             // NCA0 encrypts the entire NCA body using AES-XTS instead of
             // using different encryption types and IVs for each section.
-            Assert.Equal(0, Header.Version);
+            Assert.SdkEqual(0, Header.Version);
 
             if (openEncrypted == IsEncrypted)
             {

--- a/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
+++ b/src/LibHac/FsSystem/NcaUtils/NcaHeader.cs
@@ -254,7 +254,7 @@ namespace LibHac.FsSystem.NcaUtils
 
         private static bool CheckIfDecrypted(ReadOnlySpan<byte> header)
         {
-            Assert.True(header.Length >= 0x400);
+            Assert.SdkRequiresGreaterEqual(header.Length, 0x400);
 
             // Check the magic value
             if (header[0x200] != 'N' || header[0x201] != 'C' || header[0x202] != 'A')

--- a/src/LibHac/FsSystem/PooledBuffer.cs
+++ b/src/LibHac/FsSystem/PooledBuffer.cs
@@ -33,13 +33,13 @@ namespace LibHac.FsSystem
 
         public Span<byte> GetBuffer()
         {
-            Assert.NotNull(Array);
+            Assert.SdkRequiresNotNull(Array);
             return Array.AsSpan(0, Length);
         }
 
         public int GetSize()
         {
-            Assert.NotNull(Array);
+            Assert.SdkRequiresNotNull(Array);
             return Length;
         }
 
@@ -56,10 +56,10 @@ namespace LibHac.FsSystem
 
         private void AllocateCore(int idealSize, int requiredSize, bool enableLargeCapacity)
         {
-            Assert.Null(Array);
+            Assert.SdkRequiresNull(Array);
 
             // Check that we can allocate this size.
-            Assert.True(requiredSize <= GetAllocatableSizeMaxCore(enableLargeCapacity));
+            Assert.SdkRequiresLessEqual(requiredSize, GetAllocatableSizeMaxCore(enableLargeCapacity));
 
             int targetSize = Math.Min(Math.Max(idealSize, requiredSize),
                 GetAllocatableSizeMaxCore(enableLargeCapacity));
@@ -80,17 +80,17 @@ namespace LibHac.FsSystem
         {
             // Shrink the buffer to empty.
             Shrink(0);
-            Assert.Null(Array);
+            Assert.SdkNull(Array);
         }
 
         public void Shrink(int idealSize)
         {
-            Assert.True(idealSize <= GetAllocatableSizeMaxCore(true));
+            Assert.SdkRequiresLessEqual(idealSize, GetAllocatableSizeMaxCore(true));
 
             // Check if we actually need to shrink.
             if (Length > idealSize)
             {
-                Assert.NotNull(Array);
+                Assert.SdkRequiresNotNull(Array);
 
                 // Pretend we shrank the buffer.
                 Length = idealSize;

--- a/src/LibHac/FsSystem/UniqueLockSemaphore.cs
+++ b/src/LibHac/FsSystem/UniqueLockSemaphore.cs
@@ -80,7 +80,7 @@ namespace LibHac.FsSystem
             Shared.Move(out _semaphore, ref semaphore);
             Shared.Move(out _pinnedObject, ref pinnedObject);
 
-            Assert.True(_semaphore.IsLocked);
+            Assert.SdkAssert(_semaphore.IsLocked);
         }
 
         public void Dispose()

--- a/src/LibHac/Kernel/InitialProcessBinaryReader.cs
+++ b/src/LibHac/Kernel/InitialProcessBinaryReader.cs
@@ -64,7 +64,7 @@ namespace LibHac.Kernel
         private static Result GetKipOffsets(out (int offset, int size)[] kipOffsets, IStorage iniStorage,
             int processCount)
         {
-            Assert.True(processCount <= MaxProcessCount);
+            Assert.SdkRequiresLessEqual(processCount, MaxProcessCount);
 
             UnsafeHelpers.SkipParamInit(out kipOffsets);
 

--- a/src/LibHac/Kvdb/FlatMapKeyValueStore.cs
+++ b/src/LibHac/Kvdb/FlatMapKeyValueStore.cs
@@ -410,8 +410,8 @@ namespace LibHac.Kvdb
             public Result Initialize(int capacity, MemoryResource memoryResource)
             {
                 // Initialize must only be called once.
-                Assert.Null(_entries);
-                Assert.NotNull(memoryResource);
+                Assert.SdkRequiresNull(_entries);
+                Assert.SdkRequiresNotNull(memoryResource);
 
                 // FS uses the provided MemoryResource to allocate the KeyValue array.
                 // We can't do that here because the array will contain managed references.
@@ -487,7 +487,7 @@ namespace LibHac.Kvdb
                 if (_count > 0)
                 {
                     // The key being added must be greater than the last key in the list.
-                    Assert.True(key.CompareTo(_entries[_count - 1].Key) > 0);
+                    Assert.SdkGreater(key, _entries[_count - 1].Key);
                 }
 
                 _entries[_count] = new KeyValue(in key, value);
@@ -671,7 +671,7 @@ namespace LibHac.Kvdb
                     // An entry was added. entryIndex is the index of the new entry.
 
                     // Only one entry can be added at a time.
-                    Assert.Equal(newLength, _length + 1);
+                    Assert.SdkEqual(newLength, _length + 1);
 
                     if (entryIndex <= _index)
                     {
@@ -687,7 +687,7 @@ namespace LibHac.Kvdb
                     // An entry was removed. entryIndex is the index where the removed entry used to be.
 
                     // Only one entry can be removed at a time.
-                    Assert.Equal(newLength, _length - 1);
+                    Assert.SdkEqual(newLength, _length - 1);
 
                     if (entryIndex < _index)
                     {

--- a/src/LibHac/Kvdb/KeyValueArchive.cs
+++ b/src/LibHac/Kvdb/KeyValueArchive.cs
@@ -75,7 +75,7 @@ namespace LibHac.Kvdb
             UnsafeHelpers.SkipParamInit(out count);
 
             // This should only be called at the start of reading stream.
-            Assert.True(_offset == 0);
+            Assert.SdkRequiresEqual(_offset, 0);
 
             // Read and validate header.
             var header = new KeyValueArchiveHeader();
@@ -95,7 +95,7 @@ namespace LibHac.Kvdb
             UnsafeHelpers.SkipParamInit(out keySize, out valueSize);
 
             // This should only be called after ReadEntryCount.
-            Assert.NotEqual(_offset, 0);
+            Assert.SdkNotEqual(_offset, 0);
 
             // Peek the next entry header.
             Unsafe.SkipInit(out KeyValueArchiveEntryHeader header);
@@ -115,7 +115,7 @@ namespace LibHac.Kvdb
         public Result ReadKeyValue(Span<byte> keyBuffer, Span<byte> valueBuffer)
         {
             // This should only be called after ReadEntryCount.
-            Assert.NotEqual(_offset, 0);
+            Assert.SdkNotEqual(_offset, 0);
 
             // Read the next entry header.
             Unsafe.SkipInit(out KeyValueArchiveEntryHeader header);
@@ -127,8 +127,8 @@ namespace LibHac.Kvdb
                 return ResultKvdb.InvalidKeyValue.Log();
 
             // Key size and Value size must be correct.
-            Assert.Equal(keyBuffer.Length, header.KeySize);
-            Assert.Equal(valueBuffer.Length, header.ValueSize);
+            Assert.SdkEqual(keyBuffer.Length, header.KeySize);
+            Assert.SdkEqual(valueBuffer.Length, header.ValueSize);
 
             rc = Read(keyBuffer);
             if (rc.IsFailure()) return rc;
@@ -176,8 +176,8 @@ namespace LibHac.Kvdb
         private void Write(ReadOnlySpan<byte> source)
         {
             // Bounds check.
-            Assert.True(_offset + source.Length <= _buffer.Length &&
-                              _offset + source.Length > _offset);
+            Abort.DoAbortUnless(_offset + source.Length <= _buffer.Length &&
+                        _offset + source.Length > _offset);
 
             source.CopyTo(_buffer.Slice(_offset));
             _offset += source.Length;
@@ -186,7 +186,7 @@ namespace LibHac.Kvdb
         public void WriteHeader(int entryCount)
         {
             // This should only be called at start of write.
-            Assert.Equal(_offset, 0);
+            Assert.SdkEqual(_offset, 0);
 
             var header = new KeyValueArchiveHeader(entryCount);
             Write(SpanHelpers.AsByteSpan(ref header));
@@ -195,7 +195,7 @@ namespace LibHac.Kvdb
         public void WriteEntry(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
         {
             // This should only be called after writing header.
-            Assert.NotEqual(_offset, 0);
+            Assert.SdkNotEqual(_offset, 0);
 
             var header = new KeyValueArchiveEntryHeader(key.Length, value.Length);
             Write(SpanHelpers.AsByteSpan(ref header));

--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -29,6 +29,10 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);ENABLE_ASSERTS</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Condition="Exists('ResultNameResolver.Generated.cs')" Remove="ResultNameResolver.Archive.cs" />
     <Compile Condition="Exists('Common\Keys\DefaultKeySet.Generated.cs')" Remove="Common\Keys\DefaultKeySet.Empty.cs" />

--- a/src/LibHac/Lr/Path.cs
+++ b/src/LibHac/Lr/Path.cs
@@ -24,7 +24,7 @@ namespace LibHac.Lr
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InitEmpty(out Path path)
         {
-            Unsafe.SkipInit(out path);
+            UnsafeHelpers.SkipParamInit(out path);
             SpanHelpers.AsByteSpan(ref path)[0] = 0;
         }
 

--- a/src/LibHac/Os/Impl/InternalConditionVariable-os.net.cs
+++ b/src/LibHac/Os/Impl/InternalConditionVariable-os.net.cs
@@ -12,7 +12,7 @@ namespace LibHac.Os.Impl
 
         public void Signal()
         {
-            Assert.False(Monitor.IsEntered(_obj));
+            Assert.SdkRequires(!Monitor.IsEntered(_obj));
 
             Monitor.Enter(_obj);
             Monitor.Pulse(_obj);
@@ -21,7 +21,7 @@ namespace LibHac.Os.Impl
 
         public void Broadcast()
         {
-            Assert.False(Monitor.IsEntered(_obj));
+            Assert.SdkRequires(!Monitor.IsEntered(_obj));
 
             Monitor.Enter(_obj);
             Monitor.PulseAll(_obj);
@@ -30,7 +30,7 @@ namespace LibHac.Os.Impl
 
         public void Wait(ref InternalCriticalSection cs)
         {
-            Assert.False(Monitor.IsEntered(_obj));
+            Assert.SdkRequires(!Monitor.IsEntered(_obj));
             Abort.DoAbortUnless(cs.IsLockedByCurrentThread());
 
             // Monitor.Wait doesn't allow specifying a separate mutex object. Workaround this by manually 
@@ -45,7 +45,7 @@ namespace LibHac.Os.Impl
 
         public ConditionVariableStatus TimedWait(ref InternalCriticalSection cs, in TimeoutHelper timeoutHelper)
         {
-            Assert.False(Monitor.IsEntered(_obj));
+            Assert.SdkRequires(!Monitor.IsEntered(_obj));
             Abort.DoAbortUnless(cs.IsLockedByCurrentThread());
 
             TimeSpan remainingTime = timeoutHelper.GetTimeLeftOnTarget();

--- a/src/LibHac/Os/Impl/ReaderWriterLockImpl-os.net.cs
+++ b/src/LibHac/Os/Impl/ReaderWriterLockImpl-os.net.cs
@@ -13,7 +13,7 @@ namespace LibHac.Os.Impl
             // If we already own the lock, no additional action is needed
             if (rwLock.OwnerThread == Environment.CurrentManagedThreadId)
             {
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 1);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 1u);
             }
             // Otherwise we might need to block until we can acquire the read lock
             else
@@ -27,8 +27,8 @@ namespace LibHac.Os.Impl
                     DecReadLockWaiterCount(ref GetLockCount(ref rwLock));
                 }
 
-                Assert.True(GetWriteLockCount(in rwLock) == 0);
-                Assert.True(rwLock.OwnerThread == 0);
+                Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+                Assert.SdkEqual(rwLock.OwnerThread, 0);
             }
 
             IncReadLockCount(ref GetLockCount(ref rwLock));
@@ -41,7 +41,7 @@ namespace LibHac.Os.Impl
             // Acquire the lock if we already have write access
             if (rwLock.OwnerThread == Environment.CurrentManagedThreadId)
             {
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 1);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 1u);
 
                 IncReadLockCount(ref GetLockCount(ref rwLock));
                 return true;
@@ -55,8 +55,8 @@ namespace LibHac.Os.Impl
             }
 
             // Otherwise acquire the lock
-            Assert.True(GetWriteLockCount(in rwLock) == 0);
-            Assert.True(rwLock.OwnerThread == 0);
+            Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+            Assert.SdkEqual(rwLock.OwnerThread, 0);
 
             IncReadLockCount(ref GetLockCount(ref rwLock));
             return true;
@@ -66,13 +66,13 @@ namespace LibHac.Os.Impl
         {
             using ScopedLock<InternalCriticalSection> lk = ScopedLock.Lock(ref GetLockCount(ref rwLock).Cs);
 
-            Assert.True(GetReadLockCount(in GetLockCount(ref rwLock)) > 0);
-            DecReadLockWaiterCount(ref GetLockCount(ref rwLock));
+            Assert.SdkLess(0u, GetReadLockCount(in GetLockCount(ref rwLock)));
+            DecReadLockCount(ref GetLockCount(ref rwLock));
 
             // If we own the lock, check if we need to release ownership and signal any waiting threads
             if (rwLock.OwnerThread == Environment.CurrentManagedThreadId)
             {
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 1);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 1u);
 
                 // Return if we still hold any locks
                 if (GetWriteLockCount(in rwLock) != 0 || GetReadLockCount(in GetLockCount(ref rwLock)) != 0)
@@ -98,9 +98,9 @@ namespace LibHac.Os.Impl
             // Otherwise we need to signal the next writer if we were the only reader
             else
             {
-                Assert.True(GetWriteLockCount(in rwLock) == 0);
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 0);
-                Assert.True(rwLock.OwnerThread == 0);
+                Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 0u);
+                Assert.SdkEqual(rwLock.OwnerThread, 0);
 
                 // Signal the next writer if no readers are left
                 if (GetReadLockCount(in GetLockCount(ref rwLock)) == 0 &&
@@ -121,7 +121,7 @@ namespace LibHac.Os.Impl
             // Increase the write lock count if we already own the lock
             if (rwLock.OwnerThread == currentThread)
             {
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 1);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 1u);
 
                 IncWriteLockCount(ref rwLock);
                 return;
@@ -136,8 +136,8 @@ namespace LibHac.Os.Impl
                 DecWriteLockWaiterCount(ref GetLockCount(ref rwLock));
             }
 
-            Assert.True(GetWriteLockCount(in rwLock) == 0);
-            Assert.True(rwLock.OwnerThread == 0);
+            Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+            Assert.SdkEqual(rwLock.OwnerThread, 0);
 
             // Acquire the lock
             IncWriteLockCount(ref rwLock);
@@ -154,7 +154,7 @@ namespace LibHac.Os.Impl
             // Acquire the lock if we already have write access
             if (rwLock.OwnerThread == currentThread)
             {
-                Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) == 1);
+                Assert.SdkEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 1u);
 
                 IncWriteLockCount(ref rwLock);
                 return true;
@@ -168,8 +168,8 @@ namespace LibHac.Os.Impl
             }
 
             // Otherwise acquire the lock
-            Assert.True(GetWriteLockCount(in rwLock) == 0);
-            Assert.True(rwLock.OwnerThread == 0);
+            Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+            Assert.SdkEqual(rwLock.OwnerThread, 0);
 
             IncWriteLockCount(ref rwLock);
             SetWriteLocked(ref GetLockCount(ref rwLock));
@@ -181,9 +181,9 @@ namespace LibHac.Os.Impl
         {
             using ScopedLock<InternalCriticalSection> lk = ScopedLock.Lock(ref GetLockCount(ref rwLock).Cs);
 
-            Assert.True(GetWriteLockCount(in rwLock) > 0);
-            Assert.True(GetWriteLocked(in GetLockCount(ref rwLock)) != 0);
-            Assert.True(rwLock.OwnerThread == Environment.CurrentManagedThreadId);
+            Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+            Assert.SdkNotEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 0u);
+            Assert.SdkEqual(rwLock.OwnerThread, Environment.CurrentManagedThreadId);
 
             DecWriteLockCount(ref rwLock);
 

--- a/src/LibHac/Os/Impl/ReaderWriterLockImpl.cs
+++ b/src/LibHac/Os/Impl/ReaderWriterLockImpl.cs
@@ -67,56 +67,56 @@ namespace LibHac.Os.Impl
         public static void IncReadLockCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint readLockCount = lc.Counter.ReadLockCount;
-            Assert.True(readLockCount < ReaderWriterLock.ReaderWriterLockCountMax);
+            Assert.SdkLess(readLockCount, (uint)ReaderWriterLock.ReaderWriterLockCountMax);
             lc.Counter.ReadLockCount = readLockCount + 1;
         }
 
         public static void DecReadLockCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint readLockCount = lc.Counter.ReadLockCount;
-            Assert.True(readLockCount > 0);
+            Assert.SdkGreater(readLockCount, 0u);
             lc.Counter.ReadLockCount = readLockCount - 1;
         }
 
         public static void IncReadLockWaiterCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint readLockWaiterCount = lc.Counter.ReadLockWaiterCount;
-            Assert.True(readLockWaiterCount < ReaderWriterLock.ReadWriteLockWaiterCountMax);
+            Assert.SdkLess(readLockWaiterCount, (uint)ReaderWriterLock.ReaderWriterLockCountMax);
             lc.Counter.ReadLockWaiterCount = readLockWaiterCount + 1;
         }
 
         public static void DecReadLockWaiterCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint readLockWaiterCount = lc.Counter.ReadLockWaiterCount;
-            Assert.True(readLockWaiterCount > 0);
+            Assert.SdkGreater(readLockWaiterCount, 0u);
             lc.Counter.ReadLockWaiterCount = readLockWaiterCount - 1;
         }
 
         public static void IncWriteLockWaiterCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint writeLockWaiterCount = lc.Counter.WriteLockWaiterCount;
-            Assert.True(writeLockWaiterCount < ReaderWriterLock.ReadWriteLockWaiterCountMax);
+            Assert.SdkLess(writeLockWaiterCount, (uint)ReaderWriterLock.ReaderWriterLockCountMax);
             lc.Counter.WriteLockWaiterCount = writeLockWaiterCount + 1;
         }
 
         public static void DecWriteLockWaiterCount(ref ReaderWriterLockType.LockCountType lc)
         {
             uint writeLockWaiterCount = lc.Counter.WriteLockWaiterCount;
-            Assert.True(writeLockWaiterCount > 0);
+            Assert.SdkGreater(writeLockWaiterCount, 0u);
             lc.Counter.WriteLockWaiterCount = writeLockWaiterCount - 1;
         }
 
         public static void IncWriteLockCount(ref ReaderWriterLockType rwLock)
         {
             uint writeLockCount = rwLock.LockCount.WriteLockCount;
-            Assert.True(writeLockCount < ReaderWriterLock.ReaderWriterLockCountMax);
+            Assert.SdkLess(writeLockCount, (uint)ReaderWriterLock.ReaderWriterLockCountMax);
             rwLock.LockCount.WriteLockCount = writeLockCount + 1;
         }
 
         public static void DecWriteLockCount(ref ReaderWriterLockType rwLock)
         {
             uint writeLockCount = rwLock.LockCount.WriteLockCount;
-            Assert.True(writeLockCount > 0);
+            Assert.SdkGreater(writeLockCount, 0u);
             rwLock.LockCount.WriteLockCount = writeLockCount - 1;
         }
 

--- a/src/LibHac/Os/Impl/TickManager.cs
+++ b/src/LibHac/Os/Impl/TickManager.cs
@@ -42,7 +42,7 @@ namespace LibHac.Os.Impl
 
             // Get the tick frequency.
             long tickFreq = GetTickFrequency();
-            Assert.True(tickFreq < MaxTickFrequency);
+            Assert.SdkLess(tickFreq, MaxTickFrequency);
 
             // Clamp tick to range.
             if (ticks > GetMaxTick())
@@ -63,7 +63,7 @@ namespace LibHac.Os.Impl
                 TimeSpan ts = TimeSpan.FromSeconds(seconds) +
                               TimeSpan.FromNanoSeconds(frac * nanoSecondsPerSecond / tickFreq);
 
-                Assert.True(!(ticks > 0 && ts < default(TimeSpan) || ticks < 0 && ts > default(TimeSpan)));
+                Assert.SdkAssert(!(ticks > 0 && ts < default(TimeSpan) || ticks < 0 && ts > default(TimeSpan)));
 
                 return ts;
             }
@@ -87,7 +87,7 @@ namespace LibHac.Os.Impl
             {
                 // Get the tick frequency.
                 long tickFreq = GetTickFrequency();
-                Assert.True(tickFreq < MaxTickFrequency);
+                Assert.SdkLess(tickFreq, MaxTickFrequency);
 
                 // Convert to tick.
                 long nanoSecondsPerSecond = TimeSpan.FromSeconds(1).GetNanoSeconds();

--- a/src/LibHac/Os/ReaderWriterLock.cs
+++ b/src/LibHac/Os/ReaderWriterLock.cs
@@ -27,11 +27,11 @@ namespace LibHac.Os
 
         public static void FinalizeReaderWriterLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
 
             // Don't allow finalizing a locked lock.
-            Assert.True(ReaderWriterLockImpl.GetReadLockCount(in ReaderWriterLockImpl.GetLockCount(ref rwLock)) == 0);
-            Assert.True(ReaderWriterLockImpl.GetWriteLocked(in ReaderWriterLockImpl.GetLockCount(ref rwLock)) == 0);
+            Assert.SdkRequires(ReaderWriterLockImpl.GetReadLockCount(in ReaderWriterLockImpl.GetLockCount(ref rwLock)) == 0);
+            Assert.SdkRequires(ReaderWriterLockImpl.GetWriteLocked(in ReaderWriterLockImpl.GetLockCount(ref rwLock)) == 0);
 
             // Mark not initialized.
             rwLock.LockState = ReaderWriterLockType.State.NotInitialized;
@@ -42,43 +42,43 @@ namespace LibHac.Os
 
         public static void AcquireReadLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             os.Impl.AcquireReadLockImpl(ref rwLock);
         }
 
         public static bool TryAcquireReadLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             return os.Impl.TryAcquireReadLockImpl(ref rwLock);
         }
 
         public static void ReleaseReadLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             os.Impl.ReleaseReadLockImpl(ref rwLock);
         }
 
         public static void AcquireWriteLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             os.Impl.AcquireWriteLockImpl(ref rwLock);
         }
 
         public static bool TryAcquireWriteLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             return os.Impl.TryAcquireWriteLockImpl(ref rwLock);
         }
 
         public static void ReleaseWriteLock(this OsState os, ref ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             os.Impl.ReleaseWriteLockImpl(ref rwLock);
         }
 
         public static bool IsReadLockHeld(this OsState os, in ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             return ReaderWriterLockImpl.GetReadLockCount(in ReaderWriterLockImpl.GetLockCountRo(in rwLock)) != 0;
 
         }
@@ -86,14 +86,14 @@ namespace LibHac.Os
         // Todo: Use Horizon thread APIs
         public static bool IsWriteLockHeldByCurrentThread(this OsState os, in ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             return rwLock.OwnerThread == Environment.CurrentManagedThreadId &&
                    ReaderWriterLockImpl.GetWriteLockCount(in rwLock) != 0;
         }
 
         public static bool IsReaderWriterLockOwnerThread(this OsState os, in ReaderWriterLockType rwLock)
         {
-            Assert.True(rwLock.LockState == ReaderWriterLockType.State.Initialized);
+            Assert.SdkRequires(rwLock.LockState == ReaderWriterLockType.State.Initialized);
             return rwLock.OwnerThread == Environment.CurrentManagedThreadId;
         }
     }

--- a/src/LibHac/Util/Alignment.cs
+++ b/src/LibHac/Util/Alignment.cs
@@ -11,7 +11,7 @@ namespace LibHac.Util
 
         public static ulong AlignUpPow2(ulong value, uint alignment)
         {
-            Assert.True(BitUtil.IsPowerOfTwo(alignment));
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return ((value + invMask) & ~invMask);
@@ -19,7 +19,7 @@ namespace LibHac.Util
 
         public static ulong AlignDownPow2(ulong value, uint alignment)
         {
-            Assert.True(BitUtil.IsPowerOfTwo(alignment));
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return (value & ~invMask);
@@ -27,7 +27,7 @@ namespace LibHac.Util
 
         public static bool IsAlignedPow2(ulong value, uint alignment)
         {
-            Assert.True(BitUtil.IsPowerOfTwo(alignment));
+            Assert.SdkRequires(BitUtil.IsPowerOfTwo(alignment));
 
             ulong invMask = alignment - 1;
             return (value & invMask) == 0;

--- a/src/LibHac/Util/Optional.cs
+++ b/src/LibHac/Util/Optional.cs
@@ -14,17 +14,17 @@ namespace LibHac.Util
         {
             get
             {
-                Assert.True(_hasValue);
-                // It's beautiful
-                return ref MemoryMarshal.CreateSpan(ref _value, 1)[0];
+                Assert.SdkRequires(_hasValue);
+                // It's beautiful, working around C# rules
+                return ref MemoryMarshal.GetReference(SpanHelpers.CreateSpan(ref _value, 1));
             }
         }
         public readonly ref readonly T ValueRo
         {
             get
             {
-                Assert.True(_hasValue);
-                return ref SpanHelpers.CreateReadOnlySpan(in _value, 1)[0];
+                Assert.SdkRequires(_hasValue);
+                return ref MemoryMarshal.GetReference(SpanHelpers.CreateReadOnlySpan(in _value, 1));
             }
         }
 


### PR DESCRIPTION
Mostly imitates nnsdk's assert system. The assert handler object is global because passing around a HorizonClient object just to do asserts would be annoying.