### PR TITLE
Allow FS access log to be used without a backing FS server

### DIFF
--- a/src/LibHac/FsSystem/StorageExtensions.cs
+++ b/src/LibHac/FsSystem/StorageExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using LibHac.Common;
 using LibHac.Fs;
@@ -181,7 +182,7 @@ namespace LibHac.FsSystem
 
             storage.GetSize(out long storageSize).ThrowIfFailure();
 
-            var arr = new T[storageSize / Marshal.SizeOf<T>()];
+            var arr = new T[storageSize / Unsafe.SizeOf<T>()];
             Span<byte> dest = MemoryMarshal.Cast<T, byte>(arr.AsSpan());
 
             storage.Read(0, dest);

--- a/src/LibHac/Os/Impl/ReaderWriterLockImpl-os.net.cs
+++ b/src/LibHac/Os/Impl/ReaderWriterLockImpl-os.net.cs
@@ -181,7 +181,7 @@ namespace LibHac.Os.Impl
         {
             using ScopedLock<InternalCriticalSection> lk = ScopedLock.Lock(ref GetLockCount(ref rwLock).Cs);
 
-            Assert.SdkEqual(GetWriteLockCount(in rwLock), 0u);
+            Assert.SdkRequiresGreater(GetWriteLockCount(in rwLock), 0u);
             Assert.SdkNotEqual(GetWriteLocked(in GetLockCount(ref rwLock)), 0u);
             Assert.SdkEqual(rwLock.OwnerThread, Environment.CurrentManagedThreadId);
 

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -53,6 +53,9 @@ namespace hactoolnet
                         fs.Register(mountName.ToU8Span(), OpenFileSystem(i));
                         fs.Register("output".ToU8Span(), new LocalFileSystem(ctx.Options.SectionOutDir[i]));
 
+                        fs.Impl.EnableFileSystemAccessorAccessLog(mountName.ToU8Span());
+                        fs.Impl.EnableFileSystemAccessorAccessLog("output".ToU8Span());
+
                         FsUtils.CopyDirectoryWithProgress(fs, (mountName + ":/").ToU8Span(), "output:/".ToU8Span(), logger: ctx.Logger).ThrowIfFailure();
 
                         fs.Unmount(mountName.ToU8Span());
@@ -161,6 +164,9 @@ namespace hactoolnet
 
                         fs.Register("code".ToU8Span(), OpenFileSystemByType(NcaSectionType.Code));
                         fs.Register("output".ToU8Span(), new LocalFileSystem(ctx.Options.ExefsOutDir));
+
+                        fs.Impl.EnableFileSystemAccessorAccessLog("code".ToU8Span());
+                        fs.Impl.EnableFileSystemAccessorAccessLog("output".ToU8Span());
 
                         FsUtils.CopyDirectoryWithProgress(fs, "code:/".ToU8Span(), "output:/".ToU8Span(), logger: ctx.Logger).ThrowIfFailure();
 

--- a/src/hactoolnet/ProcessSave.cs
+++ b/src/hactoolnet/ProcessSave.cs
@@ -8,6 +8,7 @@ using LibHac.Common;
 using LibHac.Common.Keys;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Fs.Impl;
 using LibHac.FsSystem;
 using LibHac.FsSystem.Save;
 using static hactoolnet.Print;
@@ -34,6 +35,7 @@ namespace hactoolnet
                 FileSystemClient fs = ctx.Horizon.Fs;
 
                 fs.Register("save".ToU8Span(), save);
+                fs.Impl.EnableFileSystemAccessorAccessLog("save".ToU8Span());
 
                 if (ctx.Options.Validate)
                 {
@@ -43,6 +45,7 @@ namespace hactoolnet
                 if (ctx.Options.OutDir != null)
                 {
                     fs.Register("output".ToU8Span(), new LocalFileSystem(ctx.Options.OutDir));
+                    fs.Impl.EnableFileSystemAccessorAccessLog("output".ToU8Span());
 
                     FsUtils.CopyDirectoryWithProgress(fs, "save:/".ToU8Span(), "output:/".ToU8Span(), logger: ctx.Logger).ThrowIfFailure();
 
@@ -89,6 +92,7 @@ namespace hactoolnet
                     if (ctx.Options.RepackSource != null)
                     {
                         fs.Register("input".ToU8Span(), new LocalFileSystem(ctx.Options.RepackSource));
+                        fs.Impl.EnableFileSystemAccessorAccessLog("input".ToU8Span());
 
                         fs.CleanDirectoryRecursively("save:/".ToU8Span());
                         fs.Commit("save".ToU8Span());

--- a/src/hactoolnet/Program.cs
+++ b/src/hactoolnet/Program.cs
@@ -70,10 +70,7 @@ namespace hactoolnet
                 {
                     ctx.Logger = logger;
                     OpenKeySet(ctx);
-
-                    Horizon horizon = HorizonFactory.CreateWithDefaultFsConfig(new HorizonConfiguration(),
-                        new InMemoryFileSystem(), ctx.KeySet);
-                    ctx.Horizon = horizon.CreatePrivilegedHorizonClient();
+                    InitializeHorizon(ctx);
 
                     if (ctx.Options.AccessLog != null)
                     {
@@ -245,6 +242,13 @@ namespace hactoolnet
             }
 
             ctx.KeySet = keySet;
+        }
+
+        private static void InitializeHorizon(Context ctx)
+        {
+            var horizon = new Horizon(new HorizonConfiguration());
+            ctx.Horizon = horizon.CreatePrivilegedHorizonClient();
+            ctx.Horizon.Fs.SetServerlessAccessLog(true);
         }
 
         private static void ProcessKeygen(Context ctx)


### PR DESCRIPTION
Reduces the hactoolnet build size by ~260 KB due to fssrv code no longer being used