### PR TITLE
Reduce the number of crypto tests

### DIFF
--- a/tests/LibHac.Tests/CryptoTests/AesCbcTests.cs
+++ b/tests/LibHac.Tests/CryptoTests/AesCbcTests.cs
@@ -5,70 +5,130 @@ namespace LibHac.Tests.CryptoTests
 {
     public class AesCbcTests
     {
-        public static TheoryData<EncryptionTestVector> EncryptTestVectors =
+        public static EncryptionTestVector[] EncryptTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(true, "CBCVarKey128.rsp", "CBCVarTxt128.rsp", "CBCKeySbox128.rsp", "CBCGFSbox128.rsp");
+
+        public static EncryptionTestVector[] DecryptTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(false, "CBCVarKey128.rsp", "CBCVarTxt128.rsp", "CBCKeySbox128.rsp", "CBCGFSbox128.rsp");
+
+        public static EncryptionTestVector[] EncryptMultiTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(true, "CBCMMT128.rsp");
+
+        public static EncryptionTestVector[] DecryptMultiTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(false, "CBCMMT128.rsp");
+
+        [Fact]
+        public static void Encrypt()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors, (key, iv) => Aes.CreateCbcEncryptor(key, iv, true));
+        }
+
+        [Fact]
+        public static void Decrypt()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors, (key, iv) => Aes.CreateCbcDecryptor(key, iv, true));
+        }
+
+        [Fact]
+        public static void EncryptMulti()
+        {
+            Common.EncryptCipherTest(EncryptMultiTestVectors, (key, iv) => Aes.CreateCbcEncryptor(key, iv, true));
+        }
+
+        [Fact]
+        public static void DecryptMulti()
+        {
+            Common.DecryptCipherTest(DecryptMultiTestVectors, (key, iv) => Aes.CreateCbcDecryptor(key, iv, true));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void EncryptIntrinsics()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors, (key, iv) => Aes.CreateCbcEncryptor(key, iv));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void DecryptIntrinsics()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors, (key, iv) => Aes.CreateCbcDecryptor(key, iv));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void EncryptMultiIntrinsics()
+        {
+            Common.EncryptCipherTest(EncryptMultiTestVectors, (key, iv) => Aes.CreateCbcEncryptor(key, iv));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void DecryptMultiIntrinsics()
+        {
+            Common.DecryptCipherTest(DecryptMultiTestVectors, (key, iv) => Aes.CreateCbcDecryptor(key, iv));
+        }
+
+
+        // The above tests run all the test vectors in a single test to avoid having thousands of tests.
+        // Use the below tests if running each test vector as an individual test is needed.
+
+        // ReSharper disable InconsistentNaming
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+
+        public static TheoryData<EncryptionTestVector> EncryptTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(true, "CBCVarKey128.rsp", "CBCVarTxt128.rsp", "CBCKeySbox128.rsp", "CBCGFSbox128.rsp");
 
-        public static TheoryData<EncryptionTestVector> DecryptTestVectors =
+        public static TheoryData<EncryptionTestVector> DecryptTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(false, "CBCVarKey128.rsp", "CBCVarTxt128.rsp", "CBCKeySbox128.rsp", "CBCGFSbox128.rsp");
 
-        public static TheoryData<EncryptionTestVector> EncryptMultiTestVectors =
+        public static TheoryData<EncryptionTestVector> EncryptMultiTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(true, "CBCMMT128.rsp");
 
-        public static TheoryData<EncryptionTestVector> DecryptMultiTestVectors =
+        public static TheoryData<EncryptionTestVector> DecryptMultiTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(false, "CBCMMT128.rsp");
 
-        [Theory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void Encrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void Encrypt_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateCbcEncryptor(tv.Key, tv.Iv, true));
         }
 
-        [Theory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void Decrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void Decrypt_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateCbcDecryptor(tv.Key, tv.Iv, true));
         }
 
-        [Theory]
-        [MemberData(nameof(EncryptMultiTestVectors))]
-        public static void EncryptMulti(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(EncryptMultiTestVectors_Individual))]
+        public static void EncryptMulti_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateCbcEncryptor(tv.Key, tv.Iv, true));
         }
 
-        [Theory]
-        [MemberData(nameof(DecryptMultiTestVectors))]
-        public static void DecryptMulti(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(DecryptMultiTestVectors_Individual))]
+        public static void DecryptMulti_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateCbcDecryptor(tv.Key, tv.Iv, true));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void EncryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void EncryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateCbcEncryptor(tv.Key, tv.Iv));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void DecryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void DecryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateCbcDecryptor(tv.Key, tv.Iv));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(EncryptMultiTestVectors))]
-        public static void EncryptMultiIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(EncryptMultiTestVectors_Individual))]
+        public static void EncryptMultiIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateCbcEncryptor(tv.Key, tv.Iv));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(DecryptMultiTestVectors))]
-        public static void DecryptMultiIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(DecryptMultiTestVectors_Individual))]
+        public static void DecryptMultiIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateCbcDecryptor(tv.Key, tv.Iv));
         }

--- a/tests/LibHac.Tests/CryptoTests/AesEcbTests.cs
+++ b/tests/LibHac.Tests/CryptoTests/AesEcbTests.cs
@@ -5,70 +5,130 @@ namespace LibHac.Tests.CryptoTests
 {
     public class AesEcbTests
     {
-        public static TheoryData<EncryptionTestVector> EncryptTestVectors =
+        public static EncryptionTestVector[] EncryptTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(true, "ECBVarKey128.rsp", "ECBVarTxt128.rsp", "ECBKeySbox128.rsp", "ECBGFSbox128.rsp");
+
+        public static EncryptionTestVector[] DecryptTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(false, "ECBVarKey128.rsp", "ECBVarTxt128.rsp", "ECBKeySbox128.rsp", "ECBGFSbox128.rsp");
+
+        public static EncryptionTestVector[] EncryptMultiTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(true, "ECBMMT128.rsp");
+
+        public static EncryptionTestVector[] DecryptMultiTestVectors =
+            RspReader.ReadEncryptionTestVectorsArray(false, "ECBMMT128.rsp");
+
+        [Fact]
+        public static void Encrypt()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors, (key, iv) => Aes.CreateEcbEncryptor(key, true));
+        }
+
+        [Fact]
+        public static void Decrypt()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors, (key, iv) => Aes.CreateEcbDecryptor(key, true));
+        }
+
+        [Fact]
+        public static void EncryptMulti()
+        {
+            Common.EncryptCipherTest(EncryptMultiTestVectors, (key, iv) => Aes.CreateEcbEncryptor(key, true));
+        }
+
+        [Fact]
+        public static void DecryptMulti()
+        {
+            Common.DecryptCipherTest(DecryptMultiTestVectors, (key, iv) => Aes.CreateEcbDecryptor(key, true));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void EncryptIntrinsics()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors, (key, iv) => Aes.CreateEcbEncryptor(key));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void DecryptIntrinsics()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors, (key, iv) => Aes.CreateEcbDecryptor(key));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void EncryptMultiIntrinsics()
+        {
+            Common.EncryptCipherTest(EncryptMultiTestVectors, (key, iv) => Aes.CreateEcbEncryptor(key));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void DecryptMultiIntrinsics()
+        {
+            Common.DecryptCipherTest(DecryptMultiTestVectors, (key, iv) => Aes.CreateEcbDecryptor(key));
+        }
+
+
+        // The above tests run all the test vectors in a single test to avoid having thousands of tests.
+        // Use the below tests if running each test vector as an individual test is needed.
+
+        // ReSharper disable InconsistentNaming
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+
+        public static TheoryData<EncryptionTestVector> EncryptTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(true, "ECBVarKey128.rsp", "ECBVarTxt128.rsp", "ECBKeySbox128.rsp", "ECBGFSbox128.rsp");
 
-        public static TheoryData<EncryptionTestVector> DecryptTestVectors =
+        public static TheoryData<EncryptionTestVector> DecryptTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(false, "ECBVarKey128.rsp", "ECBVarTxt128.rsp", "ECBKeySbox128.rsp", "ECBGFSbox128.rsp");
 
-        public static TheoryData<EncryptionTestVector> EncryptMultiTestVectors =
+        public static TheoryData<EncryptionTestVector> EncryptMultiTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(true, "ECBMMT128.rsp");
 
-        public static TheoryData<EncryptionTestVector> DecryptMultiTestVectors =
+        public static TheoryData<EncryptionTestVector> DecryptMultiTestVectors_Individual =
             RspReader.ReadEncryptionTestVectors(false, "ECBMMT128.rsp");
 
-        [Theory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void Encrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void Encrypt_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateEcbEncryptor(tv.Key, true));
         }
 
-        [Theory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void Decrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void Decrypt_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateEcbDecryptor(tv.Key, true));
         }
 
-        [Theory]
-        [MemberData(nameof(EncryptMultiTestVectors))]
-        public static void EncryptMulti(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(EncryptMultiTestVectors_Individual))]
+        public static void EncryptMulti_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateEcbEncryptor(tv.Key, true));
         }
 
-        [Theory]
-        [MemberData(nameof(DecryptMultiTestVectors))]
-        public static void DecryptMulti(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(DecryptMultiTestVectors_Individual))]
+        public static void DecryptMulti_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateEcbDecryptor(tv.Key, true));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void EncryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void EncryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateEcbEncryptor(tv.Key));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void DecryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void DecryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateEcbDecryptor(tv.Key));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(EncryptMultiTestVectors))]
-        public static void EncryptMultiIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(EncryptMultiTestVectors_Individual))]
+        public static void EncryptMultiIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateEcbEncryptor(tv.Key));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(DecryptMultiTestVectors))]
-        public static void DecryptMultiIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(DecryptMultiTestVectors_Individual))]
+        public static void DecryptMultiIntrinsics_Individual(EncryptionTestVector tv)
         {
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateEcbDecryptor(tv.Key));
         }

--- a/tests/LibHac.Tests/CryptoTests/AesIntrinsicsRequiredAttributes.cs
+++ b/tests/LibHac.Tests/CryptoTests/AesIntrinsicsRequiredAttributes.cs
@@ -13,4 +13,15 @@ namespace LibHac.Tests.CryptoTests
             }
         }
     }
+
+    public sealed class AesIntrinsicsRequiredFactAttribute : FactAttribute
+    {
+        public AesIntrinsicsRequiredFactAttribute()
+        {
+            if (!Aes.IsAesNiSupported())
+            {
+                Skip = "AES intrinsics required";
+            }
+        }
+    }
 }

--- a/tests/LibHac.Tests/CryptoTests/AesXtsTests.cs
+++ b/tests/LibHac.Tests/CryptoTests/AesXtsTests.cs
@@ -8,13 +8,70 @@ namespace LibHac.Tests.CryptoTests
 {
     public class AesXtsTests
     {
-        public static TheoryData<EncryptionTestVector> EncryptTestVectors =
-            RemovePartialByteTests(RspReader.ReadEncryptionTestVectors(true, "XTSGenAES128.rsp"));
+        public static EncryptionTestVector[] EncryptTestVectors =
+            RemovePartialByteTests(RspReader.ReadEncryptionTestVectorsArray(true, "XTSGenAES128.rsp"));
 
-        public static TheoryData<EncryptionTestVector> DecryptTestVectors =
-            RemovePartialByteTests(RspReader.ReadEncryptionTestVectors(false, "XTSGenAES128.rsp"));
+        public static EncryptionTestVector[] DecryptTestVectors =
+            RemovePartialByteTests(RspReader.ReadEncryptionTestVectorsArray(false, "XTSGenAES128.rsp"));
 
         // The XTS implementation only supports multiples of whole bytes
+        private static EncryptionTestVector[] RemovePartialByteTests(EncryptionTestVector[] input)
+        {
+            IEnumerable<EncryptionTestVector> filteredTestVectors = input
+                .Where(x => x.DataUnitLength % 8 == 0);
+
+            var output = new List<EncryptionTestVector>();
+
+            foreach (EncryptionTestVector item in filteredTestVectors)
+            {
+                output.Add(item);
+            }
+
+            return output.ToArray();
+        }
+
+        [Fact]
+        public static void Encrypt()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors,
+                (key, iv) => Aes.CreateXtsEncryptor(key.AsSpan(0, 0x10), key.AsSpan(0x10, 0x10), iv, true));
+        }
+
+        [Fact]
+        public static void Decrypt()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors,
+                (key, iv) => Aes.CreateXtsDecryptor(key.AsSpan(0, 0x10), key.AsSpan(0x10, 0x10), iv, true));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void EncryptIntrinsics()
+        {
+            Common.EncryptCipherTest(EncryptTestVectors,
+                (key, iv) => Aes.CreateXtsEncryptor(key.AsSpan(0, 0x10), key.AsSpan(0x10, 0x10), iv));
+        }
+
+        [AesIntrinsicsRequiredFact]
+        public static void DecryptIntrinsics()
+        {
+            Common.DecryptCipherTest(DecryptTestVectors,
+                (key, iv) => Aes.CreateXtsDecryptor(key.AsSpan(0, 0x10), key.AsSpan(0x10, 0x10), iv));
+        }
+
+
+        // The above tests run all the test vectors in a single test to avoid having thousands of tests.
+        // Use the below tests if running each test vector as an individual test is needed.
+
+        // ReSharper disable InconsistentNaming
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+
+        public static TheoryData<EncryptionTestVector> EncryptTestVectors_Individual =
+            RemovePartialByteTests(RspReader.ReadEncryptionTestVectors(true, "XTSGenAES128.rsp"));
+
+        public static TheoryData<EncryptionTestVector> DecryptTestVectors_Individual =
+            RemovePartialByteTests(RspReader.ReadEncryptionTestVectors(false, "XTSGenAES128.rsp"));
+
         private static TheoryData<EncryptionTestVector> RemovePartialByteTests(TheoryData<EncryptionTestVector> input)
         {
             IEnumerable<EncryptionTestVector> filteredTestVectors = input
@@ -32,9 +89,8 @@ namespace LibHac.Tests.CryptoTests
             return output;
         }
 
-        [Theory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void Encrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void Encrypt_Individual(EncryptionTestVector tv)
         {
             Span<byte> key1 = tv.Key.AsSpan(0, 0x10);
             Span<byte> key2 = tv.Key.AsSpan(0x10, 0x10);
@@ -42,9 +98,8 @@ namespace LibHac.Tests.CryptoTests
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateXtsEncryptor(key1, key2, tv.Iv, true));
         }
 
-        [Theory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void Decrypt(EncryptionTestVector tv)
+        //[Theory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void Decrypt_Individual(EncryptionTestVector tv)
         {
             Span<byte> key1 = tv.Key.AsSpan(0, 0x10);
             Span<byte> key2 = tv.Key.AsSpan(0x10, 0x10);
@@ -52,9 +107,8 @@ namespace LibHac.Tests.CryptoTests
             Common.CipherTestCore(tv.CipherText, tv.PlainText, Aes.CreateXtsDecryptor(key1, key2, tv.Iv, true));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(EncryptTestVectors))]
-        public static void EncryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(EncryptTestVectors_Individual))]
+        public static void EncryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Span<byte> key1 = tv.Key.AsSpan(0, 0x10);
             Span<byte> key2 = tv.Key.AsSpan(0x10, 0x10);
@@ -62,9 +116,8 @@ namespace LibHac.Tests.CryptoTests
             Common.CipherTestCore(tv.PlainText, tv.CipherText, Aes.CreateXtsEncryptor(key1, key2, tv.Iv));
         }
 
-        [AesIntrinsicsRequiredTheory]
-        [MemberData(nameof(DecryptTestVectors))]
-        public static void DecryptIntrinsics(EncryptionTestVector tv)
+        //[AesIntrinsicsRequiredTheory, MemberData(nameof(DecryptTestVectors_Individual))]
+        public static void DecryptIntrinsics_Individual(EncryptionTestVector tv)
         {
             Span<byte> key1 = tv.Key.AsSpan(0, 0x10);
             Span<byte> key2 = tv.Key.AsSpan(0x10, 0x10);

--- a/tests/LibHac.Tests/CryptoTests/Common.cs
+++ b/tests/LibHac.Tests/CryptoTests/Common.cs
@@ -6,6 +6,8 @@ namespace LibHac.Tests.CryptoTests
 {
     internal static class Common
     {
+        internal delegate ICipher CipherCreator(byte[] key, byte[] iv);
+
         internal static void CipherTestCore(byte[] inputData, byte[] expected, ICipher cipher)
         {
             byte[] transformBuffer = new byte[inputData.Length];
@@ -16,9 +18,24 @@ namespace LibHac.Tests.CryptoTests
             Assert.Equal(expected, transformBuffer);
         }
 
+        internal static void EncryptCipherTest(EncryptionTestVector[] testVectors, CipherCreator cipherGenerator)
+        {
+            foreach (EncryptionTestVector tv in testVectors)
+            {
+                CipherTestCore(tv.PlainText, tv.CipherText, cipherGenerator(tv.Key, tv.Iv));
+            }
+        }
+
+        internal static void DecryptCipherTest(EncryptionTestVector[] testVectors, CipherCreator cipherGenerator)
+        {
+            foreach (EncryptionTestVector tv in testVectors)
+            {
+                CipherTestCore(tv.CipherText, tv.PlainText, cipherGenerator(tv.Key, tv.Iv));
+            }
+        }
+
         internal static void HashTestCore(ReadOnlySpan<byte> message, byte[] expectedDigest, IHash hash)
         {
-
             byte[] digestBuffer = new byte[Sha256.DigestSize];
 
             hash.Initialize();

--- a/tests/LibHac.Tests/CryptoTests/RspReader.cs
+++ b/tests/LibHac.Tests/CryptoTests/RspReader.cs
@@ -86,8 +86,21 @@ namespace LibHac.Tests.CryptoTests
 
         public static TheoryData<EncryptionTestVector> ReadEncryptionTestVectors(bool getEncryptTests, params string[] filenames)
         {
-            IEnumerable<string> resourcePaths = filenames.Select(x => $"LibHac.Tests.CryptoTests.TestVectors.{x}");
+            EncryptionTestVector[] vectorArray = ReadEncryptionTestVectorsArray(getEncryptTests, filenames);
             var testVectors = new TheoryData<EncryptionTestVector>();
+
+            foreach (EncryptionTestVector test in vectorArray)
+            {
+                testVectors.Add(test);
+            }
+
+            return testVectors;
+        }
+
+        public static EncryptionTestVector[] ReadEncryptionTestVectorsArray(bool getEncryptTests, params string[] filenames)
+        {
+            IEnumerable<string> resourcePaths = filenames.Select(x => $"LibHac.Tests.CryptoTests.TestVectors.{x}");
+            var testVectors = new List<EncryptionTestVector>();
 
             foreach (string path in resourcePaths)
             {
@@ -102,7 +115,7 @@ namespace LibHac.Tests.CryptoTests
                 }
             }
 
-            return testVectors;
+            return testVectors.ToArray();
         }
 
         public IEnumerable<HashTestVector> GetHashTestVectors()
@@ -153,8 +166,21 @@ namespace LibHac.Tests.CryptoTests
 
         public static TheoryData<HashTestVector> ReadHashTestVectors(params string[] filenames)
         {
-            IEnumerable<string> resourcePaths = filenames.Select(x => $"LibHac.Tests.CryptoTests.TestVectors.{x}");
+            HashTestVector[] vectorArray = ReadHashTestVectorsArray(filenames);
             var testVectors = new TheoryData<HashTestVector>();
+
+            foreach (HashTestVector test in vectorArray)
+            {
+                testVectors.Add(test);
+            }
+
+            return testVectors;
+        }
+
+        public static HashTestVector[] ReadHashTestVectorsArray(params string[] filenames)
+        {
+            IEnumerable<string> resourcePaths = filenames.Select(x => $"LibHac.Tests.CryptoTests.TestVectors.{x}");
+            var testVectors = new List<HashTestVector>();
 
             foreach (string path in resourcePaths)
             {
@@ -169,7 +195,7 @@ namespace LibHac.Tests.CryptoTests
                 }
             }
 
-            return testVectors;
+            return testVectors.ToArray();
         }
     }
 

--- a/tests/LibHac.Tests/CryptoTests/Sha256Tests.cs
+++ b/tests/LibHac.Tests/CryptoTests/Sha256Tests.cs
@@ -6,12 +6,31 @@ namespace LibHac.Tests.CryptoTests
 {
     public class Sha256Tests
     {
-        public static TheoryData<HashTestVector> TestVectors =
+        public static HashTestVector[] TestVectors =
+            RspReader.ReadHashTestVectorsArray("SHA256ShortMsg.rsp", "SHA256LongMsg.rsp");
+
+        [Fact]
+        public static void Encrypt()
+        {
+            foreach (HashTestVector tv in TestVectors)
+            {
+                Common.HashTestCore(tv.Message.AsSpan(0, tv.LengthBytes), tv.Digest, Sha256.CreateSha256Generator());
+            }
+        }
+
+
+        // The above tests run all the test vectors in a single test to avoid having thousands of tests.
+        // Use the below tests if running each test vector as an individual test is needed.
+
+        // ReSharper disable InconsistentNaming
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+
+        public static TheoryData<HashTestVector> TestVectors_Individual =
             RspReader.ReadHashTestVectors("SHA256ShortMsg.rsp", "SHA256LongMsg.rsp");
 
-        [Theory]
-        [MemberData(nameof(TestVectors))]
-        public static void Encrypt(HashTestVector tv)
+        //[Theory, MemberData(nameof(TestVectors_Individual))]
+        public static void Encrypt_Individual(HashTestVector tv)
         {
             Common.HashTestCore(tv.Message.AsSpan(0, tv.LengthBytes), tv.Digest, Sha256.CreateSha256Generator());
         }


### PR DESCRIPTION
Runs each crypto test vector in a single test instead of each having its own test.
The tests to run each test vector individually are still available if desired.