### PR TITLE
hactoolnet: Fix error when extracting an nca's exefs

### DIFF
--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -168,8 +168,8 @@ internal static class ProcessNca
                 {
                     FileSystemClient fs = ctx.Horizon.Fs;
 
-                    using var inputFs = new UniqueRef<IFileSystem>(OpenFileSystemByType(NcaSectionType.Data));
-                    using var outputFs = new UniqueRef<IFileSystem>(new LocalFileSystem(ctx.Options.RomfsOutDir));
+                    using var inputFs = new UniqueRef<IFileSystem>(OpenFileSystemByType(NcaSectionType.Code));
+                    using var outputFs = new UniqueRef<IFileSystem>(new LocalFileSystem(ctx.Options.ExefsOutDir));
 
                     fs.Register("code".ToU8Span(), ref inputFs.Ref());
                     fs.Register("output".ToU8Span(), ref outputFs.Ref());


### PR DESCRIPTION
Probably due to a copy/paste error in a23d01e9
Fixes #212