### PR TITLE
LocalFileSystem improvements and regression fixes for CopyDirectoryRecursively and AesXtsFile

### DIFF
--- a/src/LibHac/Common/HResult.cs
+++ b/src/LibHac/Common/HResult.cs
@@ -19,6 +19,7 @@ internal static class HResult
     public const int ERROR_ALREADY_EXISTS = unchecked((int)0x800700B7);
     public const int ERROR_DIRECTORY = unchecked((int)0x8007010B);
     public const int ERROR_SPACES_NOT_ENOUGH_DRIVES = unchecked((int)0x80E7000B);
+    public const int COR_E_IO = unchecked((int)0x80131620);
 
     public static Result HResultToHorizonResult(int hResult) => hResult switch
     {
@@ -35,6 +36,7 @@ internal static class HResult
         ERROR_ALREADY_EXISTS => ResultFs.PathAlreadyExists.Value,
         ERROR_DIRECTORY => ResultFs.PathNotFound.Value,
         ERROR_SPACES_NOT_ENOUGH_DRIVES => ResultFs.UsableSpaceNotEnough.Value,
+        COR_E_IO => ResultFs.TargetLocked.Value,
         _ => ResultFs.UnexpectedInLocalFileSystemE.Value
     };
 }

--- a/src/LibHac/FsSystem/Impl/TargetLockedAvoidance.cs
+++ b/src/LibHac/FsSystem/Impl/TargetLockedAvoidance.cs
@@ -7,7 +7,7 @@ namespace LibHac.FsSystem.Impl;
 
 internal static class TargetLockedAvoidance
 {
-    private const int RetryCount = 2;
+    private const int RetryCount = 25;
     private const int SleepTimeMs = 2;
 
     // Allow usage outside of a Horizon context by using standard .NET APIs


### PR DESCRIPTION
Fixes #215 
Fixes #216 

- Allows deleting read-only files and directories in `LocalFileSystem`
Works around Ryujinx/Ryujinx#2841