### PR TITLE
Include the pdb file in the .nupkg

### DIFF
--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -26,6 +26,9 @@
     <PathMap Condition=" '$(BuildType)' == 'Release' and '$(HasGitDir)' == 'false' ">$(MSBuildProjectDirectory)=C:/LibHac/</PathMap>
     <DeterministicSourcePaths Condition=" '$(BuildType)' == 'Release' and '$(HasGitDir)' == 'true' ">true</DeterministicSourcePaths>
 
+    <!-- Workaround https://github.com/jbevain/cecil/issues/610 by including the pdb in the main .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
@@ -41,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.5.2" PrivateAssets="All" />
     <PackageReference Include="InlineIL.Fody" Version="1.7.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Configuration for Fody -->


### PR DESCRIPTION
Using InlineIL.Fody messes up the pdb checksum which makes nuget.org consider the .snupkg to be invalid. Workaround this by including the pdb in the main .nupkg