### PR TITLE
When initializing a DirectorySaveDataFileSystem handle more possible extra data states

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: Patch
-next-version: 0.15.0
+next-version: 0.16.0
 branches:
   master:
     tag: alpha

--- a/src/LibHac/Fs/AccessLog.cs
+++ b/src/LibHac/Fs/AccessLog.cs
@@ -734,11 +734,11 @@ namespace LibHac.Fs.Impl
         public static ReadOnlySpan<byte> FsModuleName => // "$fs"
             new[] { (byte)'$', (byte)'f', (byte)'s' };
 
-        /// <summary>"<c>0.15.0</c>"</summary>
-        public static ReadOnlySpan<byte> LogLibHacVersion => // "0.15.0"
+        /// <summary>"<c>0.16.0</c>"</summary>
+        public static ReadOnlySpan<byte> LogLibHacVersion => // "0.16.0"
             new[]
             {
-                (byte)'0', (byte)'.', (byte)'1', (byte)'5', (byte)'.', (byte)'0'
+                (byte)'0', (byte)'.', (byte)'1', (byte)'6', (byte)'.', (byte)'0'
             };
 
         /// <summary>"<c>"</c>"</summary>

--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.16.0</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/hactoolnet/hactoolnet.csproj
+++ b/src/hactoolnet/hactoolnet.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.16.0</VersionPrefix>
     <PathMap Condition=" '$(BuildType)' == 'Release' ">$(MSBuildProjectDirectory)=C:/hactoolnet/</PathMap>
   </PropertyGroup>
 


### PR DESCRIPTION
Because the save data structure is stored directly on the host's file system, ending up in invalid states due to external modification can easily happen. This commit will attempt to recover the extra data when the existing `ExtraData` files are in an invalid state instead of just erroring.