### PR TITLE
Add U8Span properties to ApplicationControlProperty

### DIFF
--- a/src/LibHac/Ns/ApplicationControlProperty.cs
+++ b/src/LibHac/Ns/ApplicationControlProperty.cs
@@ -71,6 +71,11 @@ public struct ApplicationControlProperty
     public AccessibleLaunchRequiredVersionValue AccessibleLaunchRequiredVersion;
     public Array3000<byte> Reserved3448;
 
+    public U8Span IsbnString => new U8Span(Isbn.ItemsRo);
+    public U8Span DisplayVersionString => new U8Span(DisplayVersion.ItemsRo);
+    public U8Span ApplicationErrorCodeCategoryString => new U8Span(ApplicationErrorCodeCategory.ItemsRo);
+    public U8Span BcatPassphraseString => new U8Span(BcatPassphrase.ItemsRo);
+
     public struct ApplicationTitle
     {
         private Array512<byte> _name;

--- a/src/LibHac/Tools/Fs/SwitchFs.cs
+++ b/src/LibHac/Tools/Fs/SwitchFs.cs
@@ -406,14 +406,14 @@ public class Application
         {
             Name = Patch.Name;
             Version = Patch.Version;
-            DisplayVersion = Patch.Control.Value.DisplayVersion.ToString();
+            DisplayVersion = Patch.Control.Value.DisplayVersionString.ToString();
             Nacp = Patch.Control;
         }
         else if (Main != null)
         {
             Name = Main.Name;
             Version = Main.Version;
-            DisplayVersion = Main.Control.Value.DisplayVersion.ToString();
+            DisplayVersion = Main.Control.Value.DisplayVersionString.ToString();
             Nacp = Main.Control;
         }
         else

--- a/src/hactoolnet/ProcessSwitchFs.cs
+++ b/src/hactoolnet/ProcessSwitchFs.cs
@@ -245,7 +245,7 @@ internal static class ProcessSwitchFs
                 title.Version?.ToString(),
                 title.Metadata?.Type.Print(),
                 Utilities.GetBytesReadable(title.GetSize()),
-                title.Control.Value.DisplayVersion.ToString(),
+                title.Control.Value.DisplayVersionString.ToString(),
                 title.Name);
         }
 


### PR DESCRIPTION
Adds U8Span properties for the fields in `ApplicationControlProperty` that contain strings. Makes it easier to discover what these fields contain.

Fixes #233