### PR TITLE
hactoolnet: Improve NCA processing behavior

### DIFF
--- a/src/LibHac/Tools/FsSystem/Messages.cs
+++ b/src/LibHac/Tools/FsSystem/Messages.cs
@@ -3,7 +3,7 @@
 internal static class Messages
 {
     public static string DestSpanTooSmall => "Destination array is not long enough to hold the requested data.";
-    public static string NcaSectionMissing => "NCA section does not exist.";
+    public static string NcaSectionMissing => "NCA section {0} does not exist.";
     public static string DestPathIsSubPath => "The destination directory is a subdirectory of the source directory.";
     public static string DestPathAlreadyExists => "Destination path already exists.";
     public static string PartialPathNotFound => "Could not find a part of the path.";

--- a/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
@@ -146,7 +146,7 @@ public class Nca
 
     private IStorage OpenSectionStorage(int index)
     {
-        if (!SectionExists(index)) throw new ArgumentException(nameof(index), Messages.NcaSectionMissing);
+        if (!SectionExists(index)) throw new ArgumentException(string.Format(Messages.NcaSectionMissing, index), nameof(index));
 
         long offset = Header.GetSectionStartOffset(index);
         long size = Header.GetSectionSize(index);
@@ -796,7 +796,7 @@ public class Nca
 
     private IStorage OpenNca0RawStorage(int index, bool openEncrypted)
     {
-        if (!SectionExists(index)) throw new ArgumentException(nameof(index), Messages.NcaSectionMissing);
+        if (!SectionExists(index)) throw new ArgumentException(string.Format(Messages.NcaSectionMissing, index), nameof(index));
 
         long offset = Header.GetSectionStartOffset(index) - 0x400;
         long size = Header.GetSectionSize(index);

--- a/src/LibHac/Tools/FsSystem/NcaUtils/NcaExtensions.cs
+++ b/src/LibHac/Tools/FsSystem/NcaUtils/NcaExtensions.cs
@@ -55,7 +55,7 @@ public static class NcaExtensions
 
     public static Validity ValidateSectionMasterHash(this Nca nca, int index)
     {
-        if (!nca.SectionExists(index)) throw new ArgumentException(nameof(index), Messages.NcaSectionMissing);
+        if (!nca.SectionExists(index)) throw new ArgumentException(string.Format(Messages.NcaSectionMissing, index), nameof(index));
         if (!nca.CanOpenSection(index)) return Validity.MissingKey;
 
         NcaFsHeader header = nca.GetFsHeader(index);


### PR DESCRIPTION
- Ignore the relevant `--section#(dir)` option if the equivalent `--exefs(dir)` or `--romfs(dir)` option is set.
- Display a warning instead of completely erroring when trying to extract a section that doesn't exist.
- Fix an off-by-one error that resulted in section 3 not being extracted. In practice this hasn't mattered much up to this point because no official NCAs contain a section 3.