### PR TITLE
Update SaveDataFileSystemService for 14.0.0

### DIFF
--- a/build/CodeGen/results.csv
+++ b/build/CodeGen/results.csv
@@ -1070,7 +1070,7 @@ Module,DescriptionStart,DescriptionEnd,Flags,Namespace,Name,Summary
 2,6397,,,,UnsupportedOperateRangeForRegionSwitchStorage,
 
 2,6400,6449,,,PermissionDenied,
-2,6403,,,,PermissionDeniedForCreateHostFileSystem,Returned when opening a host FS on a retail device.
+2,6403,,,,HostFileSystemOperationDisabled,Returned when opening a host FS on a retail device.
 
 2,6450,,,,PortAcceptableCountLimited,
 2,6452,,,,NcaExternalKeyInconsistent,

--- a/src/LibHac/Common/FixedArrays/Array356.cs
+++ b/src/LibHac/Common/FixedArrays/Array356.cs
@@ -1,0 +1,33 @@
+﻿#pragma warning disable CS0169, CS0649, IDE0051 // Field is never used, Field is never assigned to, Remove unused private members
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace LibHac.Common.FixedArrays;
+
+public struct Array356<T>
+{
+    public const int Length = 356;
+
+    private Array256<T> _0;
+    private Array64<T> _256;
+    private Array32<T> _320;
+    private Array4<T> _352;
+
+    public ref T this[int i] => ref Items[i];
+
+    public Span<T> Items
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => SpanHelpers.CreateSpan(ref MemoryMarshal.GetReference(_0.Items), Length);
+    }
+
+    public readonly ReadOnlySpan<T> ItemsRo
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => SpanHelpers.CreateSpan(ref MemoryMarshal.GetReference(_0.ItemsRo), Length);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator ReadOnlySpan<T>(in Array356<T> value) => value.ItemsRo;
+}

--- a/src/LibHac/Diag/Log.cs
+++ b/src/LibHac/Diag/Log.cs
@@ -43,4 +43,7 @@ public static class Log
 
         diag.LogImpl(in metaData, message);
     }
+
+    /// <summary>"<c>$</c>"</summary>
+    public static ReadOnlySpan<byte> EmptyModuleName => new[] { (byte)'$' }; // "$"
 }

--- a/src/LibHac/Fs/Common/Path.cs
+++ b/src/LibHac/Fs/Common/Path.cs
@@ -94,8 +94,16 @@ public ref struct Path
     [DebuggerDisplay("{" + nameof(ToString) + "(),nq}")]
     public struct Stored : IDisposable
     {
+        private static readonly byte[] EmptyBuffer = { 0 };
+
         private byte[] _buffer;
         private int _length;
+
+        public Stored()
+        {
+            _buffer = EmptyBuffer;
+            _length = 0;
+        }
 
         public void Dispose()
         {
@@ -160,7 +168,8 @@ public ref struct Path
             byte[] oldBuffer = _buffer;
             _buffer = buffer;
 
-            if (oldBuffer is not null)
+            // Check if the buffer is longer than 1 so we don't try to return EmptyBuffer to the pool.
+            if (oldBuffer?.Length > 1)
                 ArrayPool<byte>.Shared.Return(oldBuffer);
 
             return Result.Success;

--- a/src/LibHac/Fs/Common/SaveDataTypes.cs
+++ b/src/LibHac/Fs/Common/SaveDataTypes.cs
@@ -16,8 +16,7 @@ public enum SaveDataSpaceId : byte
     Temporary = 3,
     SdUser = 4,
     ProperSystem = 100,
-    SafeMode = 101,
-    BisAuto = 127
+    SafeMode = 101
 }
 
 public enum SaveDataType : byte
@@ -99,6 +98,7 @@ public struct SaveDataExtraData
     public ulong OwnerId;
     public long TimeStamp;
     public SaveDataFlags Flags;
+    public SaveDataFormatType FormatType;
     public long DataSize;
     public long JournalSize;
     public long CommitId;
@@ -371,7 +371,7 @@ internal static class SaveDataTypesValidity
 {
     public static bool IsValid(in SaveDataAttribute attribute)
     {
-        return IsValid(in attribute.Type)&& IsValid(in attribute.Rank);
+        return IsValid(in attribute.Type) && IsValid(in attribute.Rank);
     }
 
     public static bool IsValid(in SaveDataCreationInfo creationInfo)

--- a/src/LibHac/Fs/FsEnums.cs
+++ b/src/LibHac/Fs/FsEnums.cs
@@ -46,18 +46,6 @@ public enum GameCardPartitionRaw
     RootWriteOnly = 2
 }
 
-public enum SaveDataSpaceId : byte
-{
-    System = 0,
-    User = 1,
-    SdSystem = 2,
-    Temporary = 3,
-    SdUser = 4,
-    ProperSystem = 100,
-    SafeMode = 101,
-    BisAuto = 127
-}
-
 public enum CustomStorageId
 {
     System = 0,
@@ -86,22 +74,6 @@ public enum FileSystemProxyType
     RegisteredUpdate = 8
 }
 
-public enum SaveDataMetaType : byte
-{
-    None = 0,
-    Thumbnail = 1,
-    ExtensionContext = 2
-}
-
-public enum SaveDataState : byte
-{
-    Normal = 0,
-    Processing = 1,
-    State2 = 2,
-    MarkedForDeletion = 3,
-    Extending = 4,
-    ImportSuspended = 5
-}
 
 public enum ImageDirectoryId
 {
@@ -151,48 +123,6 @@ public enum OperationId
     QueryLazyLoadCompletionRate = 5,
     SetLazyLoadPriority = 6,
     ReadyLazyLoadFile = 10001
-}
-
-public enum SaveDataType : byte
-{
-    System = 0,
-    Account = 1,
-    Bcat = 2,
-    Device = 3,
-    Temporary = 4,
-    Cache = 5,
-    SystemBcat = 6
-}
-
-public enum SaveDataRank : byte
-{
-    Primary = 0,
-    Secondary = 1
-}
-
-public enum SaveDataFormatType : byte
-{
-    Normal = 0,
-    NoJournal = 1
-}
-
-[Flags]
-public enum SaveDataFlags
-{
-    None = 0,
-    KeepAfterResettingSystemSaveData = 1 << 0,
-    KeepAfterRefurbishment = 1 << 1,
-    KeepAfterResettingSystemSaveDataWithoutUserSaveData = 1 << 2,
-    NeedsSecureDelete = 1 << 3,
-    Restore = 1 << 4
-}
-
-[Flags]
-public enum CommitOptionFlag
-{
-    None = 0,
-    ClearRestoreFlag = 1,
-    SetRestoreFlag = 2
 }
 
 public enum CacheStorageTargetMedia
@@ -293,11 +223,4 @@ public enum SdmmcPort
     Mmc = 0,
     SdCard = 1,
     GcAsic = 2
-}
-
-public enum StorageType
-{
-    SaveData = 0,
-    RomFs = 1,
-    Authoring = 2
 }

--- a/src/LibHac/Fs/Impl/SaveDataMetaPolicy.cs
+++ b/src/LibHac/Fs/Impl/SaveDataMetaPolicy.cs
@@ -4,8 +4,9 @@ namespace LibHac.Fs.Impl;
 
 internal readonly struct SaveDataMetaPolicy
 {
+    internal const int ThumbnailFileSize = 0x40060;
+
     private readonly SaveDataType _type;
-    private const int ThumbnailFileSize = 0x40060;
 
     public SaveDataMetaPolicy(SaveDataType saveType)
     {

--- a/src/LibHac/Fs/ProgramIndexMapInfo.cs
+++ b/src/LibHac/Fs/ProgramIndexMapInfo.cs
@@ -6,7 +6,7 @@ namespace LibHac.Fs;
 public struct ProgramIndexMapInfo
 {
     public ProgramId ProgramId;
-    public ProgramId MainProgramId;
+    public Ncm.ApplicationId MainProgramId;
     public byte ProgramIndex;
     public Array15<byte> Reserved;
 }

--- a/src/LibHac/Fs/ResultFs.cs
+++ b/src/LibHac/Fs/ResultFs.cs
@@ -1964,7 +1964,7 @@ public static class ResultFs
             /// <summary>Error code: 2002-6400; Range: 6400-6449; Inner value: 0x320002</summary>
             public static Result.Base PermissionDenied { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => new Result.Base(ModuleFs, 6400, 6449); }
                 /// <summary>Returned when opening a host FS on a retail device.<br/>Error code: 2002-6403; Inner value: 0x320602</summary>
-                public static Result.Base PermissionDeniedForCreateHostFileSystem => new Result.Base(ModuleFs, 6403);
+                public static Result.Base HostFileSystemOperationDisabled => new Result.Base(ModuleFs, 6403);
 
             /// <summary>Error code: 2002-6450; Inner value: 0x326402</summary>
             public static Result.Base PortAcceptableCountLimited => new Result.Base(ModuleFs, 6450);

--- a/src/LibHac/Fs/Shim/Debug.cs
+++ b/src/LibHac/Fs/Shim/Debug.cs
@@ -7,7 +7,11 @@ namespace LibHac.Fs.Shim;
 
 public enum DebugOptionKey : uint
 {
-    SaveDataEncryption = 0x20454453 // "SDE "
+    SaveDataEncryption = 0x20454453, // "SDE "
+    SaveDataJournalMetaVerification = 0x20454453, // "JMV "
+    SaveDataRemapMetaVerification = 0x20454453, // "RMV "
+    SaveDataHashAlgorithm = 0x20454453, // "SDHA"
+    SaveDataHashSalt = 0x20454453 // "SDHS"
 }
 
 /// <summary>

--- a/src/LibHac/FsSrv/FileSystemProxyImpl.cs
+++ b/src/LibHac/FsSrv/FileSystemProxyImpl.cs
@@ -352,6 +352,14 @@ public class FileSystemProxyImpl : IFileSystemProxy, IFileSystemProxyForLoader
         return saveFsService.CreateSaveDataFileSystemBySystemSaveDataId(in attribute, in creationInfo);
     }
 
+    public Result CreateSaveDataFileSystemWithCreationInfo2(in SaveDataCreationInfo2 creationInfo)
+    {
+        Result rc = GetSaveDataFileSystemService(out SaveDataFileSystemService saveFsService);
+        if (rc.IsFailure()) return rc;
+
+        return saveFsService.CreateSaveDataFileSystemWithCreationInfo2(in creationInfo);
+    }
+
     public Result ExtendSaveDataFileSystem(SaveDataSpaceId spaceId, ulong saveDataId, long dataSize,
         long journalSize)
     {

--- a/src/LibHac/FsSrv/FileSystemServerInitializer.cs
+++ b/src/LibHac/FsSrv/FileSystemServerInitializer.cs
@@ -138,6 +138,7 @@ public static class FileSystemServerInitializer
         saveFsServiceConfig.IsPseudoSaveData = () => true;
         saveFsServiceConfig.SaveDataFileSystemCacheCount = 1;
         saveFsServiceConfig.SaveIndexerManager = saveDataIndexerManager;
+        saveFsServiceConfig.DebugConfigService = debugConfigurationService;
         saveFsServiceConfig.FsServer = server;
 
         var saveFsService = new SaveDataFileSystemServiceImpl(in saveFsServiceConfig);

--- a/src/LibHac/FsSrv/FileSystemServerInitializer.cs
+++ b/src/LibHac/FsSrv/FileSystemServerInitializer.cs
@@ -136,7 +136,7 @@ public static class FileSystemServerInitializer
         saveFsServiceConfig.BufferManager = bufferManager;
         saveFsServiceConfig.GenerateRandomData = config.RandomGenerator;
         saveFsServiceConfig.IsPseudoSaveData = () => true;
-        saveFsServiceConfig.MaxSaveFsCacheCount = 1;
+        saveFsServiceConfig.SaveDataFileSystemCacheCount = 1;
         saveFsServiceConfig.SaveIndexerManager = saveDataIndexerManager;
         saveFsServiceConfig.FsServer = server;
 

--- a/src/LibHac/FsSrv/FsCreator/ILocalFileSystemCreator.cs
+++ b/src/LibHac/FsSrv/FsCreator/ILocalFileSystemCreator.cs
@@ -1,9 +1,10 @@
-﻿using LibHac.Fs.Fsa;
+﻿using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Fsa;
 
 namespace LibHac.FsSrv.FsCreator;
 
 public interface ILocalFileSystemCreator
 {
-    Result Create(out IFileSystem fileSystem, bool someBool);
-    Result Create(out IFileSystem fileSystem, string path, bool openCaseSensitive);
+    Result Create(ref SharedRef<IFileSystem> outFileSystem, in Path rootPath, bool openCaseSensitive, bool ensureRootPathExists, Result pathNotFoundResult);
 }

--- a/src/LibHac/FsSrv/FsCreator/ISaveDataFileSystemCreator.cs
+++ b/src/LibHac/FsSrv/FsCreator/ISaveDataFileSystemCreator.cs
@@ -18,5 +18,8 @@ public interface ISaveDataFileSystemCreator
     Result CreateExtraDataAccessor(ref SharedRef<ISaveDataExtraDataAccessor> outExtraDataAccessor,
         ref SharedRef<IFileSystem> baseFileSystem);
 
-    void SetSdCardEncryptionSeed(ReadOnlySpan<byte> seed);
+    Result IsDataEncrypted(out bool isEncrypted, ref SharedRef<IFileSystem> baseFileSystem, ulong saveDataId,
+        IBufferManager bufferManager, bool isDeviceUniqueMac, bool isReconstructible);
+
+    void SetMacGenerationSeed(ReadOnlySpan<byte> seed);
 }

--- a/src/LibHac/FsSrv/FsCreator/SaveDataFileSystemCreator.cs
+++ b/src/LibHac/FsSrv/FsCreator/SaveDataFileSystemCreator.cs
@@ -120,7 +120,13 @@ public class SaveDataFileSystemCreator : ISaveDataFileSystemCreator
         throw new NotImplementedException();
     }
 
-    public void SetSdCardEncryptionSeed(ReadOnlySpan<byte> seed)
+    public Result IsDataEncrypted(out bool isEncrypted, ref SharedRef<IFileSystem> baseFileSystem, ulong saveDataId,
+        IBufferManager bufferManager, bool isDeviceUniqueMac, bool isReconstructible)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetMacGenerationSeed(ReadOnlySpan<byte> seed)
     {
         throw new NotImplementedException();
     }

--- a/src/LibHac/FsSrv/ISaveDataIndexerManager.cs
+++ b/src/LibHac/FsSrv/ISaveDataIndexerManager.cs
@@ -5,7 +5,7 @@ namespace LibHac.FsSrv;
 
 public interface ISaveDataIndexerManager
 {
-    Result OpenSaveDataIndexerAccessor(ref UniqueRef<SaveDataIndexerAccessor> outAccessor, out bool neededInit, SaveDataSpaceId spaceId);
+    Result OpenSaveDataIndexerAccessor(ref UniqueRef<SaveDataIndexerAccessor> outAccessor, out bool isInitialOpen, SaveDataSpaceId spaceId);
     void ResetIndexer(SaveDataSpaceId spaceId);
     void InvalidateIndexer(SaveDataSpaceId spaceId);
 }

--- a/src/LibHac/FsSrv/Impl/ISaveDataTransferCoreInterface.cs
+++ b/src/LibHac/FsSrv/Impl/ISaveDataTransferCoreInterface.cs
@@ -2,15 +2,15 @@
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
+using LibHac.Os;
 using LibHac.Util;
-using IFileSf = LibHac.FsSrv.Sf.IFile;
 
 namespace LibHac.FsSrv.Impl;
 
 public interface ISaveDataTransferCoreInterface : IDisposable
 {
-    Result GetFreeSpaceSizeForSaveData(out long freeSpaceSize, SaveDataSpaceId spaceId);
-    Result QuerySaveDataTotalSize(out long totalSize, long dataSize, long journalSize);
+    Result GetFreeSpaceSizeForSaveData(out long outFreeSpaceSize, SaveDataSpaceId spaceId);
+    Result QuerySaveDataTotalSize(out long outTotalSize, long dataSize, long journalSize);
     Result CheckSaveDataFile(long saveDataId, SaveDataSpaceId spaceId);
     Result CreateSaveDataFileSystemCore(in SaveDataAttribute attribute, in SaveDataCreationInfo creationInfo, in SaveDataMetaInfo metaInfo, in Optional<HashSalt> hashSalt, bool leaveUnfinalized);
     Result GetSaveDataInfo(out SaveDataInfo saveInfo, SaveDataSpaceId spaceId, in SaveDataAttribute attribute);
@@ -18,13 +18,15 @@ public interface ISaveDataTransferCoreInterface : IDisposable
     Result WriteSaveDataFileSystemExtraDataCore(SaveDataSpaceId spaceId, ulong saveDataId, in SaveDataExtraData extraData, SaveDataType type, bool updateTimeStamp);
     Result FinalizeSaveDataCreation(ulong saveDataId, SaveDataSpaceId spaceId);
     Result CancelSaveDataCreation(ulong saveDataId, SaveDataSpaceId spaceId);
-    Result OpenSaveDataFile(ref SharedRef<IFileSf> file, SaveDataSpaceId spaceId, in SaveDataAttribute attribute, SaveDataMetaType metaType);
-    Result OpenSaveDataMetaFileRaw(ref SharedRef<IFile> file, SaveDataSpaceId spaceId, ulong saveDataId, SaveDataMetaType metaType, OpenMode mode);
+    Result OpenSaveDataFile(ref SharedRef<IFile> oufFile, SaveDataSpaceId spaceId, ulong saveDataId, OpenMode mode);
+    Result OpenSaveDataMetaFileRaw(ref SharedRef<IFile> outFile, SaveDataSpaceId spaceId, ulong saveDataId, SaveDataMetaType metaType, OpenMode mode);
     Result OpenSaveDataInternalStorageFileSystemCore(ref SharedRef<IFileSystem> fileSystem, SaveDataSpaceId spaceId, ulong saveDataId, bool useSecondMacKey);
+    Result OpenSaveDataFileSystemCore(ref SharedRef<IFileSystem> outFileSystem, out ulong outSaveDataId, SaveDataSpaceId spaceId, in SaveDataAttribute attribute, bool openReadOnly, bool cacheExtraData);
     Result ExtendSaveDataFileSystem(SaveDataSpaceId spaceId, ulong saveDataId, long dataSize, long journalSize);
     Result DeleteSaveDataFileSystemBySaveDataSpaceId(SaveDataSpaceId spaceId, ulong saveDataId);
     Result SwapSaveDataKeyAndState(SaveDataSpaceId spaceId, ulong saveDataId1, ulong saveDataId2);
     Result SetSaveDataState(SaveDataSpaceId spaceId, ulong saveDataId, SaveDataState state);
     Result SetSaveDataRank(SaveDataSpaceId spaceId, ulong saveDataId, SaveDataRank rank);
     Result OpenSaveDataIndexerAccessor(ref UniqueRef<SaveDataIndexerAccessor> outAccessor, SaveDataSpaceId spaceId);
+    bool IsProhibited(ref UniqueLock<SdkMutex> outLock, ApplicationId applicationId);
 }

--- a/src/LibHac/FsSrv/Impl/MultiCommitManager.cs
+++ b/src/LibHac/FsSrv/Impl/MultiCommitManager.cs
@@ -46,7 +46,7 @@ internal class MultiCommitManager : IMultiCommitManager
 {
     private const int MaxFileSystemCount = 10;
 
-    public const ulong ProgramId = 0x0100000000000000;
+    public const ulong ProgramId = 0;
     public const ulong SaveDataId = 0x8000000000000001;
     private const long SaveDataSize = 0xC000;
     private const long SaveJournalSize = 0xC000;

--- a/src/LibHac/FsSrv/SaveDataIndexerManager.cs
+++ b/src/LibHac/FsSrv/SaveDataIndexerManager.cs
@@ -122,14 +122,14 @@ internal class SaveDataIndexerManager : ISaveDataIndexerManager, IDisposable
     /// The accessor must be disposed after use.
     /// </remarks>
     /// <param name="outAccessor">If the method returns successfully, contains the created accessor.</param>
-    /// <param name="neededInit">If the method returns successfully, contains <see langword="true"/>
-    /// if the indexer needed to be initialized.</param>
+    /// <param name="isInitialOpen">If the method returns successfully, contains <see langword="true"/>
+    /// if the indexer needed to be initialized because this was the first time it was opened.</param>
     /// <param name="spaceId">The <see cref="SaveDataSpaceId"/> of the indexer to open.</param>
     /// <returns>The <see cref="Result"/> of the operation.</returns>
     public Result OpenSaveDataIndexerAccessor(ref UniqueRef<SaveDataIndexerAccessor> outAccessor,
-        out bool neededInit, SaveDataSpaceId spaceId)
+        out bool isInitialOpen, SaveDataSpaceId spaceId)
     {
-        UnsafeHelpers.SkipParamInit(out neededInit);
+        UnsafeHelpers.SkipParamInit(out isInitialOpen);
 
         if (_isBisUserRedirectionEnabled && spaceId == SaveDataSpaceId.User)
         {
@@ -226,7 +226,7 @@ internal class SaveDataIndexerManager : ISaveDataIndexerManager, IDisposable
         }
 
         outAccessor.Reset(new SaveDataIndexerAccessor(indexer, ref indexerLock.Ref()));
-        neededInit = wasIndexerInitialized;
+        isInitialOpen = wasIndexerInitialized;
         return Result.Success;
     }
 

--- a/src/LibHac/FsSrv/Sf/IFileSystemProxy.cs
+++ b/src/LibHac/FsSrv/Sf/IFileSystemProxy.cs
@@ -13,7 +13,7 @@ namespace LibHac.FsSrv.Sf;
 /// <summary>
 /// The interface most programs use to interact with the FS service.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on FS 14.1.0 (nnSdk 14.3.0)</remarks>
 public interface IFileSystemProxy : IDisposable
 {
     Result SetCurrentProcess(ulong processId);
@@ -42,6 +42,7 @@ public interface IFileSystemProxy : IDisposable
     Result GetCacheStorageSize(out long dataSize, out long journalSize, ushort index);
     Result CreateSaveDataFileSystemWithHashSalt(in SaveDataAttribute attribute, in SaveDataCreationInfo creationInfo, in SaveDataMetaInfo metaInfo, in HashSalt hashSalt);
     Result OpenHostFileSystemWithOption(ref SharedRef<IFileSystemSf> outFileSystem, in FspPath path, MountHostOption option);
+    Result CreateSaveDataFileSystemWithCreationInfo2(in SaveDataCreationInfo2 creationInfo);
     Result OpenSaveDataFileSystem(ref SharedRef<IFileSystemSf> outFileSystem, SaveDataSpaceId spaceId, in SaveDataAttribute attribute);
     Result OpenSaveDataFileSystemBySystemSaveDataId(ref SharedRef<IFileSystemSf> outFileSystem, SaveDataSpaceId spaceId, in SaveDataAttribute attribute);
     Result OpenReadOnlySaveDataFileSystem(ref SharedRef<IFileSystemSf> outFileSystem, SaveDataSpaceId spaceId, in SaveDataAttribute attribute);

--- a/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/SaveDataManagement.cs
+++ b/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/SaveDataManagement.cs
@@ -307,7 +307,7 @@ public class SaveDataManagement
 
         Span<ProgramIndexMapInfo> mapInfo = stackalloc ProgramIndexMapInfo[5];
 
-        var mainProgramId = new ProgramId(0x123456);
+        var mainProgramId = new Ncm.ApplicationId(0x123456);
         var programId = new ProgramId(mainProgramId.Value + 2);
 
         for (int i = 0; i < mapInfo.Length; i++)

--- a/tests/LibHac.Tests/Fs/TypeLayoutTests.cs
+++ b/tests/LibHac.Tests/Fs/TypeLayoutTests.cs
@@ -42,6 +42,32 @@ public class TypeLayoutTests
     }
 
     [Fact]
+    public static void SaveDataCreationInfo2_Layout()
+    {
+        var s = new SaveDataCreationInfo2();
+
+        Assert.Equal(0x200, Unsafe.SizeOf<SaveDataCreationInfo2>());
+
+        Assert.Equal(0x00, GetOffset(in s, in s.Version));
+        Assert.Equal(0x08, GetOffset(in s, in s.Attribute));
+        Assert.Equal(0x48, GetOffset(in s, in s.Size));
+        Assert.Equal(0x50, GetOffset(in s, in s.JournalSize));
+        Assert.Equal(0x58, GetOffset(in s, in s.BlockSize));
+        Assert.Equal(0x60, GetOffset(in s, in s.OwnerId));
+        Assert.Equal(0x68, GetOffset(in s, in s.Flags));
+        Assert.Equal(0x6C, GetOffset(in s, in s.SpaceId));
+        Assert.Equal(0x6D, GetOffset(in s, in s.FormatType));
+        Assert.Equal(0x6E, GetOffset(in s, in s.Reserved1));
+        Assert.Equal(0x70, GetOffset(in s, in s.IsHashSaltEnabled));
+        Assert.Equal(0x71, GetOffset(in s, in s.Reserved2));
+        Assert.Equal(0x74, GetOffset(in s, in s.HashSalt));
+        Assert.Equal(0x94, GetOffset(in s, in s.MetaType));
+        Assert.Equal(0x95, GetOffset(in s, in s.Reserved3));
+        Assert.Equal(0x98, GetOffset(in s, in s.MetaSize));
+        Assert.Equal(0x9C, GetOffset(in s, in s.Reserved4));
+    }
+
+    [Fact]
     public static void SaveDataFilter_Layout()
     {
         var s = new SaveDataFilter();

--- a/tests/LibHac.Tests/Fs/TypeLayoutTests.cs
+++ b/tests/LibHac.Tests/Fs/TypeLayoutTests.cs
@@ -136,6 +136,7 @@ public class TypeLayoutTests
         Assert.Equal(0x40, GetOffset(in s, in s.OwnerId));
         Assert.Equal(0x48, GetOffset(in s, in s.TimeStamp));
         Assert.Equal(0x50, GetOffset(in s, in s.Flags));
+        Assert.Equal(0x54, GetOffset(in s, in s.FormatType));
         Assert.Equal(0x58, GetOffset(in s, in s.DataSize));
         Assert.Equal(0x60, GetOffset(in s, in s.JournalSize));
         Assert.Equal(0x68, GetOffset(in s, in s.CommitId));

--- a/tests/LibHac.Tests/FsSrv/ProgramIndexMapInfoTests.cs
+++ b/tests/LibHac.Tests/FsSrv/ProgramIndexMapInfoTests.cs
@@ -34,7 +34,7 @@ public class ProgramIndexMapInfoTests
 
         for (int i = 0; i < map.Length; i++)
         {
-            map[i].MainProgramId = new ProgramId(1);
+            map[i].MainProgramId = new Ncm.ApplicationId(1);
             map[i].ProgramId = new ProgramId((ulong)(i + 1));
             map[i].ProgramIndex = (byte)i;
         }
@@ -60,7 +60,7 @@ public class ProgramIndexMapInfoTests
 
         for (int i = 0; i < map.Length; i++)
         {
-            map[i].MainProgramId = new ProgramId((ulong)idCreator(0));
+            map[i].MainProgramId = new Ncm.ApplicationId((ulong)idCreator(0));
             map[i].ProgramId = new ProgramId((ulong)idCreator(i));
             map[i].ProgramIndex = (byte)i;
         }


### PR DESCRIPTION
- Multiple structs that hold parameters for creating save data were combined into a new `SaveDataCreationInfo2` struct.
- Extra data is now written to more save data file system types.
- Add `CreateSaveDataFileSystemWithCreationInfo2` to `IFileSystemProxy`
- Implement some more functions in `SaveDataFileSystemService` and `SaveDataFileSystemServiceImpl`
- Ensure all functions in `SaveDataFileSystemService` and `SaveDataFileSystemServiceImpl` are accurate to FS 14.0.0