### PR TITLE
Update FS shim classes for 14.0.0

### DIFF
--- a/src/LibHac/Fs/AccessLog.cs
+++ b/src/LibHac/Fs/AccessLog.cs
@@ -988,6 +988,15 @@ namespace LibHac.Fs.Impl
                 (byte)'i', (byte)'d', (byte)':', (byte)' '
             };
 
+        /// <summary>"<c>, imagedirectoryid: </c>"</summary>
+        public static ReadOnlySpan<byte> LogImageDirectoryId => // ", imagedirectoryid: "
+            new[]
+            {
+                (byte)',', (byte)' ', (byte)'i', (byte)'m', (byte)'a', (byte)'g', (byte)'e', (byte)'d',
+                (byte)'i', (byte)'r', (byte)'e', (byte)'c', (byte)'t', (byte)'o', (byte)'r', (byte)'y',
+                (byte)'i', (byte)'d', (byte)':', (byte)' '
+            };
+
         /// <summary>"<c>, gamecard_handle: 0x</c>"</summary>
         public static ReadOnlySpan<byte> LogGameCardHandle => // ", gamecard_handle: 0x"
             new[]

--- a/src/LibHac/Fs/AccessLog.cs
+++ b/src/LibHac/Fs/AccessLog.cs
@@ -241,6 +241,16 @@ namespace LibHac.Fs.Impl
             }
         }
 
+        public ReadOnlySpan<byte> ToString(SaveDataFormatType value)
+        {
+            switch (value)
+            {
+                case SaveDataFormatType.Normal: return new[] { (byte)'N', (byte)'o', (byte)'r', (byte)'m', (byte)'a', (byte)'l' };
+                case SaveDataFormatType.NoJournal: return new[] { (byte)'N', (byte)'o', (byte)'J', (byte)'o', (byte)'u', (byte)'r', (byte)'n', (byte)'a', (byte)'l' };
+                default: return ToValueString((int)value);
+            }
+        }
+
         public ReadOnlySpan<byte> ToString(ContentType value)
         {
             switch (value)
@@ -1081,6 +1091,16 @@ namespace LibHac.Fs.Impl
                 (byte)',', (byte)' ', (byte)'s', (byte)'a', (byte)'v', (byte)'e', (byte)'d', (byte)'a',
                 (byte)'t', (byte)'a', (byte)'s', (byte)'p', (byte)'a', (byte)'c', (byte)'e', (byte)'i',
                 (byte)'d', (byte)':', (byte)' '
+            };
+
+        /// <summary>"<c>, save_data_format_type: </c>"</summary>
+        public static ReadOnlySpan<byte> LogSaveDataFormatType => // ", save_data_format_type: "
+            new[]
+            {
+                (byte)',', (byte)' ', (byte)'s', (byte)'a', (byte)'v', (byte)'e', (byte)'_', (byte)'d',
+                (byte)'a', (byte)'t', (byte)'a', (byte)'_', (byte)'f', (byte)'o', (byte)'r', (byte)'m',
+                (byte)'a', (byte)'t', (byte)'_', (byte)'t', (byte)'y', (byte)'p', (byte)'e', (byte)':',
+                (byte)' '
             };
 
         /// <summary>"<c>, save_data_time_stamp: </c>"</summary>

--- a/src/LibHac/Fs/Shim/Application.cs
+++ b/src/LibHac/Fs/Shim/Application.cs
@@ -14,7 +14,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting application packages.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class Application
 {

--- a/src/LibHac/Fs/Shim/BaseFileSystem.cs
+++ b/src/LibHac/Fs/Shim/BaseFileSystem.cs
@@ -1,0 +1,68 @@
+﻿using LibHac.Common;
+using LibHac.Fs.Fsa;
+using LibHac.Fs.Impl;
+using LibHac.FsSrv.Sf;
+
+using IFileSystem = LibHac.Fs.Fsa.IFileSystem;
+using IFileSystemSf = LibHac.FsSrv.Sf.IFileSystem;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for mounting base file systems.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class BaseFileSystem
+{
+    private static Result OpenBaseFileSystem(FileSystemClient fs, ref SharedRef<IFileSystemSf> outFileSystem,
+        BaseFileSystemId fileSystemId)
+    {
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+
+        Result rc = fileSystemProxy.Get.OpenBaseFileSystem(ref outFileSystem, fileSystemId);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+
+    private static Result RegisterFileSystem(FileSystemClient fs, U8Span mountName,
+        ref SharedRef<IFileSystemSf> fileSystem)
+    {
+        using var fileSystemAdapter =
+            new UniqueRef<IFileSystem>(new FileSystemServiceObjectAdapter(ref fileSystem.Ref()));
+
+        Result rc = fs.Register(mountName, ref fileSystemAdapter.Ref());
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+
+    public static Result MountBaseFileSystem(this FileSystemClient fs, U8Span mountName, BaseFileSystemId fileSystemId)
+    {
+        Result rc = fs.Impl.CheckMountName(mountName);
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        using var fileSystem = new SharedRef<IFileSystemSf>();
+        rc = OpenBaseFileSystem(fs, ref fileSystem.Ref(), fileSystemId);
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        rc = RegisterFileSystem(fs, mountName, ref fileSystem.Ref());
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+
+    public static Result FormatBaseFileSystem(this FileSystemClient fs, BaseFileSystemId fileSystemId)
+    {
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+
+        Result rc = fileSystemProxy.Get.FormatBaseFileSystem(fileSystemId);
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+}

--- a/src/LibHac/Fs/Shim/BcatSaveData.cs
+++ b/src/LibHac/Fs/Shim/BcatSaveData.cs
@@ -16,7 +16,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting BCAT save data.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class BcatSaveData
 {

--- a/src/LibHac/Fs/Shim/Bis.cs
+++ b/src/LibHac/Fs/Shim/Bis.cs
@@ -19,7 +19,7 @@ namespace LibHac.Fs.Shim;
 /// Contains functions for mounting built-in-storage partition file systems
 /// and opening the raw partitions as <see cref="IStorage"/>s.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class Bis
 {

--- a/src/LibHac/Fs/Shim/Code.cs
+++ b/src/LibHac/Fs/Shim/Code.cs
@@ -15,7 +15,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting code file systems.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class Code
 {

--- a/src/LibHac/Fs/Shim/Content.cs
+++ b/src/LibHac/Fs/Shim/Content.cs
@@ -16,7 +16,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting content file systems.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class Content
 {

--- a/src/LibHac/Fs/Shim/ContentStorage.cs
+++ b/src/LibHac/Fs/Shim/ContentStorage.cs
@@ -16,7 +16,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting the directories where content is stored.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class ContentStorage
 {

--- a/src/LibHac/Fs/Shim/CustomStorage.cs
+++ b/src/LibHac/Fs/Shim/CustomStorage.cs
@@ -13,7 +13,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting custom storage file systems.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class CustomStorage
 {

--- a/src/LibHac/Fs/Shim/Debug.cs
+++ b/src/LibHac/Fs/Shim/Debug.cs
@@ -17,7 +17,7 @@ public enum DebugOptionKey : uint
 /// <summary>
 /// Contains debug-related functions for the FS service.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class DebugShim
 {
     public static Result CreatePaddingFile(this FileSystemClient fs, long size)

--- a/src/LibHac/Fs/Shim/DeviceSaveData.cs
+++ b/src/LibHac/Fs/Shim/DeviceSaveData.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using LibHac.Common;
+using LibHac.Diag;
+using LibHac.Fs.Fsa;
+using LibHac.Fs.Impl;
+using LibHac.FsSrv.Sf;
+using LibHac.Ncm;
+using LibHac.Os;
+using IFileSystem = LibHac.Fs.Fsa.IFileSystem;
+using IFileSystemSf = LibHac.FsSrv.Sf.IFileSystem;
+
+using static LibHac.Fs.Impl.AccessLogStrings;
+using static LibHac.Fs.SaveData;
+
+namespace LibHac.Fs.Shim;
+
+public static class DeviceSaveData
+{
+    private class DeviceSaveDataAttributeGetter : ISaveDataAttributeGetter
+    {
+        private ProgramId _programId;
+
+        public DeviceSaveDataAttributeGetter(ProgramId programId)
+        {
+            _programId = programId;
+        }
+
+        public void Dispose() { }
+
+        public Result GetSaveDataAttribute(out SaveDataAttribute attribute)
+        {
+            Result rc = SaveDataAttribute.Make(out attribute, _programId, SaveDataType.Device, InvalidUserId,
+                InvalidSystemSaveDataId);
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+
+    private const SaveDataSpaceId DeviceSaveDataSpaceId = SaveDataSpaceId.User;
+
+    private static Result MountDeviceSaveDataImpl(this FileSystemClientImpl fs, U8Span mountName,
+        in SaveDataAttribute attribute)
+    {
+        Result rc = fs.CheckMountName(mountName);
+        if (rc.IsFailure()) return rc;
+
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.GetFileSystemProxyServiceObject();
+        using var fileSystem = new SharedRef<IFileSystemSf>();
+
+        rc = fileSystemProxy.Get.OpenSaveDataFileSystem(ref fileSystem.Ref(), DeviceSaveDataSpaceId, in attribute);
+        if (rc.IsFailure()) return rc.Miss();
+
+        var fileSystemAdapterRaw = new FileSystemServiceObjectAdapter(ref fileSystem.Ref());
+        using var fileSystemAdapter = new UniqueRef<IFileSystem>(fileSystemAdapterRaw);
+
+        if (!fileSystemAdapter.HasValue)
+            return ResultFs.AllocationMemoryFailedInDeviceSaveDataA.Log();
+
+        using var saveDataAttributeGetter =
+            new UniqueRef<ISaveDataAttributeGetter>(new DeviceSaveDataAttributeGetter(attribute.ProgramId));
+
+        using var mountNameGenerator = new UniqueRef<ICommonMountNameGenerator>();
+
+        rc = fs.Fs.Register(mountName, fileSystemAdapterRaw, ref fileSystemAdapter.Ref(), ref mountNameGenerator.Ref(),
+            ref saveDataAttributeGetter.Ref(), useDataCache: false, storageForPurgeFileDataCache: null,
+            usePathCache: true);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+
+    public static Result MountDeviceSaveData(this FileSystemClient fs, U8Span mountName)
+    {
+        Span<byte> logBuffer = stackalloc byte[0x30];
+
+        Result rc = SaveDataAttribute.Make(out SaveDataAttribute attribute, InvalidProgramId, SaveDataType.Device,
+            InvalidUserId, InvalidSystemSaveDataId);
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = MountDeviceSaveDataImpl(fs.Impl, mountName, in attribute);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogName).Append(mountName).Append(LogQuote);
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = MountDeviceSaveDataImpl(fs.Impl, mountName, in attribute);
+        }
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+            fs.Impl.EnableFileSystemAccessorAccessLog(mountName);
+
+        return Result.Success;
+    }
+
+    public static Result MountDeviceSaveData(this FileSystemClient fs, U8Span mountName,
+        Ncm.ApplicationId applicationId)
+    {
+        Span<byte> logBuffer = stackalloc byte[0x50];
+
+        Result rc = SaveDataAttribute.Make(out SaveDataAttribute attribute, applicationId, SaveDataType.Device,
+            InvalidUserId, InvalidSystemSaveDataId);
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = MountDeviceSaveDataImpl(fs.Impl, mountName, in attribute);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogName).Append(mountName).Append(LogQuote)
+                .Append(LogApplicationId).AppendFormat(applicationId.Value, 'X');
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = MountDeviceSaveDataImpl(fs.Impl, mountName, in attribute);
+        }
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+            fs.Impl.EnableFileSystemAccessorAccessLog(mountName);
+
+        return Result.Success;
+    }
+
+    public static Result MountDeviceSaveData(this FileSystemClient fs, U8Span mountName, ApplicationId applicationId)
+    {
+        return MountDeviceSaveData(fs, mountName, new Ncm.ApplicationId(applicationId.Value));
+    }
+
+    public static bool IsDeviceSaveDataExisting(this FileSystemClient fs, ApplicationId applicationId)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x30];
+
+        bool exists;
+        var appId = new Ncm.ApplicationId(applicationId.Value);
+
+        if (fs.Impl.IsEnabledAccessLog() && fs.Impl.IsEnabledHandleAccessLog(null))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = fs.Impl.IsSaveDataExisting(out exists, appId, SaveDataType.Device, InvalidUserId);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogApplicationId).AppendFormat(applicationId.Value, 'X');
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = fs.Impl.IsSaveDataExisting(out exists, appId, SaveDataType.Device, InvalidUserId);
+        }
+
+        fs.Impl.LogResultErrorMessage(rc);
+        Abort.DoAbortUnless(rc.IsSuccess());
+
+        return exists;
+    }
+}

--- a/src/LibHac/Fs/Shim/ErrorInfo.cs
+++ b/src/LibHac/Fs/Shim/ErrorInfo.cs
@@ -1,0 +1,23 @@
+﻿using LibHac.Common;
+using LibHac.FsSrv.Sf;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for obtaining error information from the file system proxy service.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class ErrorInfo
+{
+    public static Result GetAndClearFileSystemProxyErrorInfo(this FileSystemClient fs,
+        out FileSystemProxyErrorInfo outErrorInfo)
+    {
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+
+        Result rc = fileSystemProxy.Get.GetAndClearErrorInfo(out outErrorInfo);
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+}

--- a/src/LibHac/Fs/Shim/FileDataCache.cs
+++ b/src/LibHac/Fs/Shim/FileDataCache.cs
@@ -10,11 +10,17 @@ namespace LibHac.Fs.Impl
     /// <summary>
     /// Handles getting scoped read access to the global file data cache.
     /// </summary>
-    /// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+    /// <remarks>Based on nnSdk 14.3.0</remarks>
     internal struct GlobalFileDataCacheAccessorReadableScopedPointer : IDisposable
     {
         private FileDataCacheAccessor _accessor;
         private ReaderWriterLock _lock;
+
+        public GlobalFileDataCacheAccessorReadableScopedPointer()
+        {
+            _accessor = null;
+            _lock = null;
+        }
 
         public void Dispose()
         {
@@ -36,6 +42,10 @@ namespace LibHac.Fs.Impl
 
 namespace LibHac.Fs.Shim
 {
+    /// <summary>
+    /// Contains functions for configuring the global file data cache.
+    /// </summary>
+    /// <remarks>Based on nnSdk 14.3.0</remarks>
     public static class FileDataCacheShim
     {
         internal struct Globals : IDisposable

--- a/src/LibHac/Fs/Shim/FileDataCacheAccessor.cs
+++ b/src/LibHac/Fs/Shim/FileDataCacheAccessor.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using LibHac.Fs.Fsa;
 
+// ReSharper disable once CheckNamespace
 namespace LibHac.Fs.Impl;
 
 /// <summary>
 /// Provides access to an <see cref="IFileDataCache"/>.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 internal class FileDataCacheAccessor
 {
     private readonly IFileDataCache _cache;

--- a/src/LibHac/Fs/Shim/FileSystemServiceObjectAdapter.cs
+++ b/src/LibHac/Fs/Shim/FileSystemServiceObjectAdapter.cs
@@ -21,7 +21,7 @@ namespace LibHac.Fs.Impl;
 /// An adapter for using an <see cref="IFileSf"/> service object as an <see cref="IFile"/>. Used
 /// when receiving a Horizon IPC file object so it can be used as an <see cref="IFile"/> locally.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 internal class FileServiceObjectAdapter : IFile
 {
     private SharedRef<IFileSf> _baseFile;
@@ -87,7 +87,7 @@ internal class FileServiceObjectAdapter : IFile
 /// An adapter for using an <see cref="IDirectorySf"/> service object as an <see cref="IDirectory"/>. Used
 /// when receiving a Horizon IPC directory object so it can be used as an <see cref="IDirectory"/> locally.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 internal class DirectoryServiceObjectAdapter : IDirectory
 {
     private SharedRef<IDirectorySf> _baseDirectory;
@@ -119,7 +119,7 @@ internal class DirectoryServiceObjectAdapter : IDirectory
 /// An adapter for using an <see cref="IFileSystemSf"/> service object as an <see cref="IFileSystem"/>. Used
 /// when receiving a Horizon IPC file system object so it can be used as an <see cref="IFileSystem"/> locally.
 /// </summary>
-/// <remarks>Based on FS 13.1.0 (nnSdk 13.4.0)</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 internal class FileSystemServiceObjectAdapter : IFileSystem, IMultiCommitTarget
 {
     private SharedRef<IFileSystemSf> _baseFs;

--- a/src/LibHac/Fs/Shim/FsStackUsage.cs
+++ b/src/LibHac/Fs/Shim/FsStackUsage.cs
@@ -1,0 +1,21 @@
+﻿using LibHac.Common;
+using LibHac.Diag;
+using LibHac.FsSrv.Sf;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for getting the amount of stack space used by FS threads.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class FsStackUsage
+{
+    public static uint GetFsStackUsage(this FileSystemClient fs, FsStackUsageThreadType threadType)
+    {
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+
+        Abort.DoAbortUnlessSuccess(fileSystemProxy.Get.GetFsStackUsage(out uint stackUsage, threadType));
+
+        return stackUsage;
+    }
+}

--- a/src/LibHac/Fs/Shim/GameCard.cs
+++ b/src/LibHac/Fs/Shim/GameCard.cs
@@ -14,6 +14,10 @@ using IStorageSf = LibHac.FsSrv.Sf.IStorage;
 
 namespace LibHac.Fs.Shim;
 
+/// <summary>
+/// Contains functions used for mounting and interacting with the game card.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class GameCard
 {
@@ -32,13 +36,13 @@ public static class GameCard
 
     private class GameCardCommonMountNameGenerator : ICommonMountNameGenerator
     {
-        private GameCardHandle Handle { get; }
-        private GameCardPartition PartitionId { get; }
+        private readonly GameCardHandle _handle;
+        private readonly GameCardPartition _partitionId;
 
         public GameCardCommonMountNameGenerator(GameCardHandle handle, GameCardPartition partitionId)
         {
-            Handle = handle;
-            PartitionId = partitionId;
+            _handle = handle;
+            _partitionId = partitionId;
         }
 
         public void Dispose() { }
@@ -50,7 +54,7 @@ public static class GameCard
             // Determine how much space we need.
             int requiredNameBufferSize =
                 StringUtils.GetLength(CommonMountNames.GameCardFileSystemMountName, PathTool.MountNameLengthMax) +
-                StringUtils.GetLength(GetGameCardMountNameSuffix(PartitionId), PathTool.MountNameLengthMax) +
+                StringUtils.GetLength(GetGameCardMountNameSuffix(_partitionId), PathTool.MountNameLengthMax) +
                 handleDigitCount + 2;
 
             Assert.SdkRequiresGreaterEqual(nameBuffer.Length, requiredNameBufferSize);
@@ -58,8 +62,8 @@ public static class GameCard
             // Generate the name.
             var sb = new U8StringBuilder(nameBuffer);
             sb.Append(CommonMountNames.GameCardFileSystemMountName)
-                .Append(GetGameCardMountNameSuffix(PartitionId))
-                .AppendFormat(Handle.Value, 'x', (byte)handleDigitCount)
+                .Append(GetGameCardMountNameSuffix(_partitionId))
+                .AppendFormat(_handle.Value, 'x', (byte)handleDigitCount)
                 .Append(StringTraits.DriveSeparator);
 
             Assert.SdkEqual(sb.Length, requiredNameBufferSize - 1);

--- a/src/LibHac/Fs/Shim/Host.cs
+++ b/src/LibHac/Fs/Shim/Host.cs
@@ -19,7 +19,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting file systems from a host computer.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class Host
 {

--- a/src/LibHac/Fs/Shim/ImageDirectory.cs
+++ b/src/LibHac/Fs/Shim/ImageDirectory.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using LibHac.Common;
+using LibHac.Fs.Fsa;
+using LibHac.Fs.Impl;
+using LibHac.FsSrv.Sf;
+using LibHac.Os;
+using IFileSystem = LibHac.Fs.Fsa.IFileSystem;
+using IFileSystemSf = LibHac.FsSrv.Sf.IFileSystem;
+
+using static LibHac.Fs.Impl.AccessLogStrings;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for mounting the directories where images and videos are saved.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class ImageDirectory
+{
+    public static Result MountImageDirectory(this FileSystemClient fs, U8Span mountName, ImageDirectoryId directoryId)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x50];
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.System))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = Mount(fs, mountName, directoryId);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var idString = new IdString();
+            var sb = new U8StringBuilder(logBuffer, true);
+
+            sb.Append(LogName).Append(mountName).Append(LogQuote)
+                .Append(LogImageDirectoryId).Append(idString.ToString(directoryId));
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = Mount(fs, mountName, directoryId);
+        }
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.System))
+            fs.Impl.EnableFileSystemAccessorAccessLog(mountName);
+
+        return Result.Success;
+
+        static Result Mount(FileSystemClient fs, U8Span mountName, ImageDirectoryId directoryId)
+        {
+            Result rc = fs.Impl.CheckMountName(mountName);
+            if (rc.IsFailure()) return rc.Miss();
+
+            using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+            using var fileSystem = new SharedRef<IFileSystemSf>();
+
+            rc = fileSystemProxy.Get.OpenImageDirectoryFileSystem(ref fileSystem.Ref(), directoryId);
+            if (rc.IsFailure()) return rc.Miss();
+
+            using var fileSystemAdapter =
+                new UniqueRef<IFileSystem>(new FileSystemServiceObjectAdapter(ref fileSystem.Ref()));
+
+            if (!fileSystemAdapter.HasValue)
+                return ResultFs.AllocationMemoryFailedInImageDirectoryA.Log();
+
+            rc = fs.Impl.Fs.Register(mountName, ref fileSystemAdapter.Ref());
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/LibHac/Fs/Shim/LoaderApi.cs
+++ b/src/LibHac/Fs/Shim/LoaderApi.cs
@@ -7,7 +7,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for use by the Loader service.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class LoaderApi
 {
     public static Result IsArchivedProgram(this FileSystemClient fs, out bool isArchived, ProcessId processId)

--- a/src/LibHac/Fs/Shim/Logo.cs
+++ b/src/LibHac/Fs/Shim/Logo.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using LibHac.Common;
+using LibHac.Fs.Fsa;
+using LibHac.Fs.Impl;
+using LibHac.FsSrv.Sf;
+using LibHac.Ncm;
+using LibHac.Os;
+using IFileSystem = LibHac.Fs.Fsa.IFileSystem;
+using IFileSystemSf = LibHac.FsSrv.Sf.IFileSystem;
+
+using static LibHac.Fs.Impl.AccessLogStrings;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for opening the logo partitions of NCA files.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class Logo
+{
+    public static Result MountLogo(this FileSystemClient fs, U8Span mountName, U8Span path, ProgramId programId)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x300];
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.System))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = Mount(fs, mountName, path, programId);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+
+            sb.Append(LogName).Append(mountName).Append(LogQuote)
+                .Append(LogPath).Append(path).Append(LogQuote)
+                .Append(LogProgramId).AppendFormat(programId.Value, 'X');
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = Mount(fs, mountName, path, programId);
+        }
+
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.System))
+            fs.Impl.EnableFileSystemAccessorAccessLog(mountName);
+
+        return Result.Success;
+
+        static Result Mount(FileSystemClient fs, U8Span mountName, U8Span path, ProgramId programId)
+        {
+            Result rc = fs.Impl.CheckMountName(mountName);
+            if (rc.IsFailure()) return rc.Miss();
+
+            rc = PathUtility.ConvertToFspPath(out FspPath sfPath, path);
+            if (rc.IsFailure()) return rc;
+
+            using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+            using var fileSystem = new SharedRef<IFileSystemSf>();
+
+            rc = fileSystemProxy.Get.OpenFileSystemWithId(ref fileSystem.Ref(), in sfPath, programId.Value,
+                FileSystemProxyType.Logo);
+            if (rc.IsFailure()) return rc.Miss();
+
+            using var fileSystemAdapter =
+                new UniqueRef<IFileSystem>(new FileSystemServiceObjectAdapter(ref fileSystem.Ref()));
+
+            if (!fileSystemAdapter.HasValue)
+                return ResultFs.AllocationMemoryFailedInLogoA.Log();
+
+            rc = fs.Impl.Fs.Register(mountName, ref fileSystemAdapter.Ref());
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/LibHac/Fs/Shim/MemoryReportInfo.cs
+++ b/src/LibHac/Fs/Shim/MemoryReportInfo.cs
@@ -1,0 +1,22 @@
+﻿using LibHac.Common;
+using LibHac.FsSrv.Sf;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains functions for obtaining reports on memory usage from the file system proxy service.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+public static class MemoryReportInfoShim
+{
+    public static Result GetAndClearMemoryReportInfo(this FileSystemClient fs, out MemoryReportInfo reportInfo)
+    {
+        using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+
+        Result rc = fileSystemProxy.Get.GetAndClearMemoryReportInfo(out reportInfo);
+        fs.Impl.AbortIfNeeded(rc);
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+    }
+}

--- a/src/LibHac/Fs/Shim/PosixTime.cs
+++ b/src/LibHac/Fs/Shim/PosixTime.cs
@@ -6,7 +6,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for setting the current time used by FS.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class PosixTimeShim
 {
     public static Result SetCurrentPosixTime(this FileSystemClient fs, Time.PosixTime currentPosixTime,

--- a/src/LibHac/Fs/Shim/ProgramIndexMapInfo.cs
+++ b/src/LibHac/Fs/Shim/ProgramIndexMapInfo.cs
@@ -9,7 +9,7 @@ namespace LibHac.Fs.Shim;
 /// Contains functions for registering multi-program application
 /// information of the currently running application with FS.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class ProgramIndexMapInfoShim
 {
     /// <summary>

--- a/src/LibHac/Fs/Shim/ProgramRegistry.cs
+++ b/src/LibHac/Fs/Shim/ProgramRegistry.cs
@@ -12,7 +12,7 @@ namespace LibHac.Fs.Shim;
 /// Contains functions for registering and unregistering currently running
 /// processes and their permissions in the FS program registry.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class ProgramRegistry
 {
     /// <inheritdoc cref="ProgramRegistryImpl.RegisterProgram"/>

--- a/src/LibHac/Fs/Shim/RightsId.cs
+++ b/src/LibHac/Fs/Shim/RightsId.cs
@@ -8,7 +8,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for working with rights IDs and external keys for NCA encryption.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class RightsIdShim
 {
     public static Result GetRightsId(this FileSystemClient fs, out RightsId rightsId, ProgramId programId,

--- a/src/LibHac/Fs/Shim/SaveDataForDebug.cs
+++ b/src/LibHac/Fs/Shim/SaveDataForDebug.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using LibHac.Common;
+using LibHac.Diag;
+using LibHac.Fs.Impl;
+using LibHac.FsSrv.Sf;
+using LibHac.Os;
+
+using static LibHac.Fs.Impl.AccessLogStrings;
+using static LibHac.Fs.SaveData;
+
+namespace LibHac.Fs.Shim;
+
+/// <summary>
+/// Contains save data functions used for debugging during development.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
+[SkipLocalsInit]
+public static class SaveDataForDebug
+{
+    private const long SaveDataSizeForDebug = 0x2000000;
+    private const long SaveDataJournalSizeForDebug = 0x2000000;
+
+    public static void SetSaveDataRootPath(this FileSystemClient fs, U8Span path)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x300];
+
+        if (fs.Impl.IsEnabledAccessLog() && fs.Impl.IsEnabledHandleAccessLog(null))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = SetRootPath(fs, path);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogPath).Append(path).Append(LogQuote);
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = SetRootPath(fs, path);
+        }
+
+        fs.Impl.LogResultErrorMessage(rc);
+        Abort.DoAbortUnlessSuccess(rc);
+
+        static Result SetRootPath(FileSystemClient fs, U8Span path)
+        {
+            Result rc = PathUtility.ConvertToFspPath(out FspPath sfPath, path);
+            if (rc.IsFailure()) return rc.Miss();
+
+            using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+            rc = fileSystemProxy.Get.SetSaveDataRootPath(in sfPath);
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+
+    public static void UnsetSaveDataRootPath(this FileSystemClient fs)
+    {
+        Result rc;
+
+        if (fs.Impl.IsEnabledAccessLog() && fs.Impl.IsEnabledHandleAccessLog(null))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+            rc = fileSystemProxy.Get.UnsetSaveDataRootPath();
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, U8Span.Empty);
+        }
+        else
+        {
+            using SharedRef<IFileSystemProxy> fileSystemProxy = fs.Impl.GetFileSystemProxyServiceObject();
+            rc = fileSystemProxy.Get.UnsetSaveDataRootPath();
+        }
+
+        fs.Impl.LogResultErrorMessage(rc);
+        Abort.DoAbortUnlessSuccess(rc);
+    }
+
+    /// <summary>
+    /// Ensures the current application's debug save data is at least as large as the specified values.
+    /// </summary>
+    /// <remarks>Each application can have a single debug save. This save data is not associated with any
+    /// user account and is intended for debug use when developing an application.</remarks>
+    /// <param name="fs">The <see cref="FileSystemClient"/> to use.</param>
+    /// <param name="saveDataSize">The size of the usable space in the save data.</param>
+    /// <param name="saveDataJournalSize">The size of the save data's journal.</param>
+    /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+    /// <see cref="ResultFs.TargetNotFound"/>: The save data was not found.<br/>
+    /// <see cref="ResultFs.TargetLocked"/>: The save data is currently open or otherwise in use.<br/>
+    /// <see cref="ResultFs.UsableSpaceNotEnough"/>: Insufficient free space to create or extend the save data.<br/>
+    /// <see cref="ResultFs.PermissionDenied"/>: Insufficient permissions.</returns>
+    public static Result EnsureSaveDataForDebug(this FileSystemClient fs, long saveDataSize, long saveDataJournalSize)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x60];
+
+        if (fs.Impl.IsEnabledAccessLog() && fs.Impl.IsEnabledHandleAccessLog(null))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = Ensure(fs, saveDataSize, saveDataJournalSize);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogSaveDataSize).AppendFormat(saveDataSize, 'd')
+                .Append(LogSaveDataJournalSize).AppendFormat(saveDataJournalSize, 'd');
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = Ensure(fs, saveDataSize, saveDataJournalSize);
+        }
+
+        if (rc.IsFailure()) return rc.Miss();
+
+        return Result.Success;
+
+        static Result Ensure(FileSystemClient fs, long saveDataSize, long saveDataJournalSize)
+        {
+            UserId userIdForDebug = InvalidUserId;
+
+            Result rc = fs.Impl.EnsureSaveDataImpl(userIdForDebug, saveDataSize, saveDataJournalSize,
+                extendIfNeeded: true);
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+
+    /// <summary>
+    /// Mounts the debug save data for the current application. Each application can have its own debug save
+    /// that is not associated with any user account.
+    /// </summary>
+    /// <remarks>Each application can have a single debug save. This save data is not associated with any
+    /// user account and is intended for debug use when developing an application.</remarks>
+    /// <param name="fs">The <see cref="FileSystemClient"/> to use.</param>
+    /// <param name="mountName">The mount name at which the file system will be mounted.</param>
+    /// <returns><see cref="Result.Success"/>: The operation was successful.<br/>
+    /// <see cref="ResultFs.TargetNotFound"/>: The save data was not found.<br/>
+    /// <see cref="ResultFs.TargetLocked"/>: The save data is currently open or otherwise in use.<br/>
+    /// <see cref="ResultFs.PermissionDenied"/>: Insufficient permissions.</returns>
+    public static Result MountSaveDataForDebug(this FileSystemClient fs, U8Span mountName)
+    {
+        Result rc;
+        Span<byte> logBuffer = stackalloc byte[0x30];
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+        {
+            Tick start = fs.Hos.Os.GetSystemTick();
+            rc = Mount(fs, mountName);
+            Tick end = fs.Hos.Os.GetSystemTick();
+
+            var sb = new U8StringBuilder(logBuffer, true);
+            sb.Append(LogName).Append(mountName).Append(LogQuote);
+
+            fs.Impl.OutputAccessLog(rc, start, end, null, new U8Span(sb.Buffer));
+        }
+        else
+        {
+            rc = Mount(fs, mountName);
+        }
+
+        if (rc.IsFailure()) return rc.Miss();
+
+        if (fs.Impl.IsEnabledAccessLog(AccessLogTarget.Application))
+            fs.Impl.EnableFileSystemAccessorAccessLog(mountName);
+
+        return Result.Success;
+
+        static Result Mount(FileSystemClient fs, U8Span mountName)
+        {
+            UserId userIdForDebug = InvalidUserId;
+
+            Result rc = fs.Impl.EnsureSaveDataImpl(userIdForDebug, SaveDataSizeForDebug, SaveDataJournalSizeForDebug,
+                extendIfNeeded: false);
+            if (rc.IsFailure()) return rc.Miss();
+
+            rc = fs.Impl.MountSaveDataImpl(mountName, userIdForDebug);
+            if (rc.IsFailure()) return rc.Miss();
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/LibHac/Fs/Shim/SaveDataTransferAdapter.cs
+++ b/src/LibHac/Fs/Shim/SaveDataTransferAdapter.cs
@@ -12,7 +12,7 @@ namespace LibHac.Fs.Impl;
 /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataChunkIterator"/>
 /// IPC service object via the non-IPC <see cref="ISaveDataChunkIterator"/> interface.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public class SaveDataChunkIterator : ISaveDataChunkIterator
 {
     private SharedRef<FsSrv.Sf.ISaveDataChunkIterator> _baseInterface;
@@ -61,7 +61,7 @@ public class SaveDataChunkIterator : ISaveDataChunkIterator
 /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataChunkExporter"/>
 /// IPC service object via the non-IPC <see cref="ISaveDataChunkExporter"/> interface.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public class SaveDataChunkExporter : ISaveDataChunkExporter
 {
     private SharedRef<FsSrv.Sf.ISaveDataChunkExporter> _baseInterface;
@@ -108,7 +108,7 @@ public class SaveDataChunkExporter : ISaveDataChunkExporter
 /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataChunkImporter"/>
 /// IPC service object via the non-IPC <see cref="ISaveDataChunkImporter"/> interface.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public class SaveDataChunkImporter : ISaveDataChunkImporter
 {
     private SharedRef<FsSrv.Sf.ISaveDataChunkImporter> _baseInterface;
@@ -141,7 +141,7 @@ public class SaveDataChunkImporter : ISaveDataChunkImporter
 /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataDivisionExporter"/>
 /// IPC service object via the non-IPC <see cref="ISaveDataDivisionExporter"/> interface.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public class SaveDataExporterVersion2 : ISaveDataDivisionExporter
 {
     private SharedRef<FsSrv.Sf.ISaveDataDivisionExporter> _baseInterface;
@@ -320,7 +320,7 @@ public class SaveDataExporterVersion2 : ISaveDataDivisionExporter
 /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataDivisionImporter"/>
 /// IPC service object via the non-IPC <see cref="ISaveDataDivisionImporter"/> interface.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public class SaveDataImporterVersion2 : ISaveDataDivisionImporter
 {
     private SharedRef<FsSrv.Sf.ISaveDataDivisionImporter> _baseInterface;

--- a/src/LibHac/Fs/Shim/SaveDataTransferVersion2.cs
+++ b/src/LibHac/Fs/Shim/SaveDataTransferVersion2.cs
@@ -14,6 +14,11 @@ using static LibHac.Fs.SaveData;
 // ReSharper disable once CheckNamespace
 namespace LibHac.Fs
 {
+    /// <summary>
+    /// An adapter for interacting with an <see cref="FsSrv.Sf.ISaveDataTransferManagerWithDivision"/>
+    /// IPC service object.
+    /// </summary>
+    /// <remarks>Based on nnSdk 14.3.0</remarks>
     public class SaveDataTransferManagerVersion2 : IDisposable
     {
         private SharedRef<ISaveDataTransferManagerWithDivision> _baseInterface;
@@ -253,6 +258,11 @@ namespace LibHac.Fs
         }
     }
 
+    /// <summary>
+    /// An adapter that automatically closes a given <see cref="FsSrv.Sf.ISaveDataTransferProhibiter"/>
+    /// IPC service object when disposed.
+    /// </summary>
+    /// <remarks>Based on nnSdk 14.3.0</remarks>
     public class SaveDataTransferProhibiterForCloudBackUp : IDisposable
     {
         private SharedRef<ISaveDataTransferProhibiter> _prohibiter;
@@ -271,6 +281,10 @@ namespace LibHac.Fs
 
 namespace LibHac.Fs.Shim
 {
+    /// <summary>
+    /// Contains functions used when doing save data cloud backup.
+    /// </summary>
+    /// <remarks>Based on nnSdk 14.3.0</remarks>
     public static class SaveDataTransferVersion2Shim
     {
         public static Result OpenSaveDataTransferProhibiterForCloudBackUp(this FileSystemClientImpl fs,

--- a/src/LibHac/Fs/Shim/SdCard.cs
+++ b/src/LibHac/Fs/Shim/SdCard.cs
@@ -12,6 +12,10 @@ using IFileSystemSf = LibHac.FsSrv.Sf.IFileSystem;
 
 namespace LibHac.Fs.Shim;
 
+/// <summary>
+/// Contains functions used for mounting and interacting with the SD card.
+/// </summary>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class SdCard
 {

--- a/src/LibHac/Fs/Shim/SdmmcControl.cs
+++ b/src/LibHac/Fs/Shim/SdmmcControl.cs
@@ -5,7 +5,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for suspending, resuming, and checking sdmmc status.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class SdmmcControl
 {
     public static Result GetSdmmcConnectionStatus(this FileSystemClient fs, out SdmmcSpeedMode speedMode,

--- a/src/LibHac/Fs/Shim/SignedSystemPartition.cs
+++ b/src/LibHac/Fs/Shim/SignedSystemPartition.cs
@@ -9,7 +9,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for checking if a mounted file system was created from a signed system partition.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 public static class SignedSystemPartition
 {
     public static bool IsValidSignedSystemPartitionOnSdCard(this FileSystemClient fs, U8Span path)

--- a/src/LibHac/Fs/Shim/SpeedEmulation.cs
+++ b/src/LibHac/Fs/Shim/SpeedEmulation.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace LibHac.Fs
+{
+    public enum SpeedEmulationMode
+    {
+        None = 0,
+        Faster = 1,
+        Slower = 2,
+        Random = 3
+    }
+}
+
+namespace LibHac.Fs.Shim
+{
+    public static class SpeedEmulationShim
+    {
+        public static Result SetSpeedEmulationMode(this FileSystemClient fs, SpeedEmulationMode mode)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Result GetSpeedEmulationMode(this FileSystemClient fs, out SpeedEmulationMode outMode)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/LibHac/Fs/Shim/SystemSaveData.cs
+++ b/src/LibHac/Fs/Shim/SystemSaveData.cs
@@ -16,7 +16,7 @@ namespace LibHac.Fs.Shim;
 /// <summary>
 /// Contains functions for mounting system save data file systems.
 /// </summary>
-/// <remarks>Based on nnSdk 13.4.0</remarks>
+/// <remarks>Based on nnSdk 14.3.0</remarks>
 [SkipLocalsInit]
 public static class SystemSaveData
 {

--- a/src/LibHac/FsSrv/SaveDataFileSystemService.cs
+++ b/src/LibHac/FsSrv/SaveDataFileSystemService.cs
@@ -147,6 +147,7 @@ internal class SaveDataFileSystemService : ISaveDataTransferCoreInterface, ISave
             }
             else if (attribute.Type == SaveDataType.Account && attribute.UserId == InvalidUserId)
             {
+                // Trying to create a program's debug save.
                 bool canAccess =
                     accessControl.CanCall(OperationType.CreateSaveData) ||
                     accessControl.CanCall(OperationType.DebugSaveData);
@@ -193,6 +194,7 @@ internal class SaveDataFileSystemService : ISaveDataTransferCoreInterface, ISave
             }
             else if (attribute.Type == SaveDataType.Account)
             {
+                // We need debug save data permissions to open a debug save.
                 bool canAccess = attribute.UserId != InvalidUserId ||
                                  accessControl.CanCall(OperationType.DebugSaveData);
 
@@ -303,11 +305,11 @@ internal class SaveDataFileSystemService : ISaveDataTransferCoreInterface, ISave
                     {
                         canAccess |= accessControl.CanCall(OperationType.ExtendOwnSaveData);
 
-                        bool hasDebugAccess = accessControl.CanCall(OperationType.DebugSaveData)
-                                              && attribute.Type == SaveDataType.Account
-                                              && attribute.UserId == UserId.InvalidId;
+                        bool canAccessDebugSave = accessControl.CanCall(OperationType.DebugSaveData)
+                                                  && attribute.Type == SaveDataType.Account
+                                                  && attribute.UserId == UserId.InvalidId;
 
-                        canAccess |= hasDebugAccess;
+                        canAccess |= canAccessDebugSave;
 
                         if (!canAccess)
                             return ResultFs.PermissionDenied.Log();
@@ -351,11 +353,11 @@ internal class SaveDataFileSystemService : ISaveDataTransferCoreInterface, ISave
             {
                 canAccess |= accessControl.CanCall(OperationType.ReadOwnSaveDataFileSystemExtraData);
 
-                bool hasDebugAccess = accessControl.CanCall(OperationType.DebugSaveData)
-                                      && attribute.Type == SaveDataType.Account
-                                      && attribute.UserId == UserId.InvalidId;
+                bool canAccessDebugSave = accessControl.CanCall(OperationType.DebugSaveData)
+                                          && attribute.Type == SaveDataType.Account
+                                          && attribute.UserId == UserId.InvalidId;
 
-                canAccess |= hasDebugAccess;
+                canAccess |= canAccessDebugSave;
             }
 
             if (!canAccess)
@@ -442,11 +444,11 @@ internal class SaveDataFileSystemService : ISaveDataTransferCoreInterface, ISave
                 AccessControl accessControl = programInfo.AccessControl;
                 canAccess = accessControl.CanCall(OperationType.FindOwnSaveDataWithFilter);
 
-                bool hasDebugAccess = accessControl.CanCall(OperationType.DebugSaveData)
-                                      && filter.Attribute.Type == SaveDataType.Account
-                                      && filter.Attribute.UserId == UserId.InvalidId;
+                bool canAccessDebugSave = accessControl.CanCall(OperationType.DebugSaveData)
+                                        && filter.Attribute.Type == SaveDataType.Account
+                                        && filter.Attribute.UserId == UserId.InvalidId;
 
-                canAccess |= hasDebugAccess;
+                canAccess |= canAccessDebugSave;
             }
             else
             {

--- a/tests/LibHac.Tests/Fs/FileSystemClientTests/FileSystemServerFactory.cs
+++ b/tests/LibHac.Tests/Fs/FileSystemClientTests/FileSystemServerFactory.cs
@@ -2,27 +2,45 @@
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
 using LibHac.FsSrv;
+using LibHac.FsSrv.Impl;
 using LibHac.FsSystem;
+using LibHac.Ncm;
 using LibHac.Tools.Fs;
 
 namespace LibHac.Tests.Fs.FileSystemClientTests;
 
+public class HorizonServerSet
+{
+    public Horizon Server { get; set; }
+    public HorizonClient FsProcessClient { get; set; }
+    public HorizonClient InitialProcessClient { get; set; }
+    public HorizonClient Client { get; set; }
+    public FileSystemServer FsServer { get; set; }
+    public IFileSystem RootFileSystem { get; set; }
+}
+
 public static class FileSystemServerFactory
 {
-    private static Horizon CreateHorizonImpl(bool sdCardInserted, out IFileSystem rootFs)
+    private static HorizonServerSet CreateHorizonImpl(bool sdCardInserted = true,
+        AccessControlBits.Bits fsAcBits = AccessControlBits.Bits.Debug, ProgramLocation programLocation = default)
     {
-        rootFs = new InMemoryFileSystem();
+        var hos = new HorizonServerSet();
+        hos.RootFileSystem = new InMemoryFileSystem();
         var keySet = new KeySet();
 
-        var horizon = new Horizon(new HorizonConfiguration());
+        hos.Server = new Horizon(new HorizonConfiguration());
 
-        HorizonClient fsServerClient = horizon.CreatePrivilegedHorizonClient();
-        var fsServer = new FileSystemServer(fsServerClient);
+        hos.FsProcessClient = hos.Server.CreatePrivilegedHorizonClient();
+        hos.FsServer = new FileSystemServer(hos.FsProcessClient);
+
+        hos.InitialProcessClient = hos.Server.CreatePrivilegedHorizonClient();
 
         var random = new Random(12345);
         RandomDataGenerator randomGenerator = buffer => random.NextBytes(buffer);
 
-        var defaultObjects = DefaultFsServerObjects.GetDefaultEmulatedCreators(rootFs, keySet, fsServer, randomGenerator);
+        var defaultObjects =
+            DefaultFsServerObjects.GetDefaultEmulatedCreators(hos.RootFileSystem, keySet, hos.FsServer,
+                randomGenerator);
 
         defaultObjects.SdCard.SetSdCardInsertionStatus(sdCardInserted);
 
@@ -32,31 +50,45 @@ public static class FileSystemServerFactory
         config.ExternalKeySet = new ExternalKeySet();
         config.RandomGenerator = randomGenerator;
 
-        FileSystemServerInitializer.InitializeWithConfig(fsServerClient, fsServer, config);
-        return horizon;
-    }
+        FileSystemServerInitializer.InitializeWithConfig(hos.FsProcessClient, hos.FsServer, config);
+        hos.FsServer.SetDebugFlagEnabled(true);
 
-    private static FileSystemClient CreateClientImpl(bool sdCardInserted, out IFileSystem rootFs)
-    {
-        Horizon horizon = CreateHorizonImpl(sdCardInserted, out rootFs);
+        if (programLocation.ProgramId == ProgramId.InvalidId)
+        {
+            hos.Client = hos.Server.CreateHorizonClient();
+        }
+        else
+        {
+            hos.Client = hos.Server.CreateHorizonClient(programLocation, fsAcBits);
+        }
 
-        HorizonClient horizonClient = horizon.CreatePrivilegedHorizonClient();
-
-        return horizonClient.Fs;
+        return hos;
     }
 
     public static FileSystemClient CreateClient(bool sdCardInserted)
     {
-        return CreateClientImpl(sdCardInserted, out _);
+        HorizonServerSet hos = CreateHorizonImpl(sdCardInserted: sdCardInserted);
+
+        return hos.InitialProcessClient.Fs;
     }
 
     public static FileSystemClient CreateClient(out IFileSystem rootFs)
     {
-        return CreateClientImpl(false, out rootFs);
+        HorizonServerSet hos = CreateHorizonImpl(sdCardInserted: true);
+        rootFs = hos.RootFileSystem;
+
+        return hos.InitialProcessClient.Fs;
     }
 
     public static Horizon CreateHorizonServer()
     {
-        return CreateHorizonImpl(true, out _);
+        return CreateHorizonImpl(sdCardInserted: true).Server;
+    }
+
+    public static HorizonServerSet CreateHorizon(ProgramId programId = default, bool sdCardInserted = true,
+        AccessControlBits.Bits fsAcBits = AccessControlBits.Bits.Debug)
+    {
+        var programLocation = new ProgramLocation(programId, StorageId.BuiltInUser);
+        return CreateHorizonImpl(sdCardInserted, fsAcBits, programLocation);
     }
 }

--- a/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/DeviceSaveData.cs
+++ b/tests/LibHac.Tests/Fs/FileSystemClientTests/ShimTests/DeviceSaveData.cs
@@ -1,0 +1,65 @@
+﻿using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Shim;
+using LibHac.FsSrv.Impl;
+using Xunit;
+
+namespace LibHac.Tests.Fs.FileSystemClientTests.ShimTests;
+
+public class DeviceSaveData
+{
+    [Fact]
+    public static void MountDeviceSaveData_SaveDoesNotExist_ReturnsTargetNotFound()
+    {
+        var applicationId = new Ncm.ApplicationId(1234);
+        HorizonServerSet hos = FileSystemServerFactory.CreateHorizon(applicationId, fsAcBits: AccessControlBits.Bits.FullPermission);
+
+        Assert.Result(ResultFs.TargetNotFound, hos.Client.Fs.MountDeviceSaveData("device".ToU8Span(), applicationId));
+        Assert.Result(ResultFs.TargetNotFound, hos.Client.Fs.MountDeviceSaveData("device2".ToU8Span()));
+    }
+
+    [Fact]
+    public static void MountDeviceSaveData_OwnDeviceSaveExists_ReturnsSuccess()
+    {
+        var applicationId = new Ncm.ApplicationId(1234);
+        HorizonServerSet hos = FileSystemServerFactory.CreateHorizon(applicationId, fsAcBits: AccessControlBits.Bits.FullPermission);
+
+        Assert.Success(hos.Client.Fs.CreateDeviceSaveData(applicationId, applicationId.Value, 0, 0, SaveDataFlags.None));
+        Assert.Success(hos.Client.Fs.MountDeviceSaveData("device".ToU8Span()));
+        Assert.Success(hos.Client.Fs.MountDeviceSaveData("device2".ToU8Span(), applicationId));
+    }
+
+    [Fact]
+    public static void MountDeviceSaveData_OtherDeviceSaveExists_ReturnsSuccess()
+    {
+        var ownApplicationId = new Ncm.ApplicationId(1234);
+        var otherApplicationId = new Ncm.ApplicationId(12345);
+        HorizonServerSet hos = FileSystemServerFactory.CreateHorizon(ownApplicationId, fsAcBits: AccessControlBits.Bits.FullPermission);
+
+        Assert.Success(hos.Client.Fs.CreateDeviceSaveData(otherApplicationId, otherApplicationId.Value, 0, 0, SaveDataFlags.None));
+        Assert.Success(hos.Client.Fs.MountDeviceSaveData("device".ToU8Span(), otherApplicationId));
+
+        // Try to open missing own device save data
+        Assert.Result(ResultFs.TargetNotFound, hos.Client.Fs.MountDeviceSaveData("device2".ToU8Span()));
+    }
+
+    [Fact]
+    public static void IsDeviceSaveDataExisting_ReturnsCorrectState()
+    {
+        var applicationId = new ApplicationId(1234);
+        var ncmApplicationId = new Ncm.ApplicationId(applicationId.Value);
+        HorizonServerSet hos = FileSystemServerFactory.CreateHorizon(ncmApplicationId);
+        FileSystemClient fs = hos.InitialProcessClient.Fs;
+
+        // Should return false when there aren't any saves.
+        Assert.False(fs.IsDeviceSaveDataExisting(applicationId));
+
+        // Should return true after creating the save.
+        Assert.Success(fs.CreateDeviceSaveData(ncmApplicationId, applicationId.Value, 0, 0, SaveDataFlags.None));
+        Assert.True(fs.IsDeviceSaveDataExisting(applicationId));
+
+        // Should return false after deleting the save.
+        Assert.Success(fs.DeleteDeviceSaveData(applicationId));
+        Assert.False(fs.IsDeviceSaveDataExisting(applicationId));
+    }
+}


### PR DESCRIPTION
Update FS shim classes for 14.0.0 and implement some additional ones

Needed updates:
- `SaveData`
- `SaveDataManagement`

Newly added:
- `BaseFileSystem`
- `DeviceSaveData`
- `ErrorInfo`
- `FsStackUsage`
- `ImageDirectory`
- `Logo`
- `MemoryReportInfo`
- `SaveDataForDebug`