### PR TITLE
Fix `E_ACCESSDENIED` error when renaming directory

### DIFF
--- a/src/LibHac/FsSystem/LocalFileSystem.cs
+++ b/src/LibHac/FsSystem/LocalFileSystem.cs
@@ -785,7 +785,16 @@ public class LocalFileSystem : IAttributeFileSystem
 
         try
         {
-            source.MoveTo(dest.FullName);
+            Directory.CreateDirectory(dest.FullName);
+            foreach (DirectoryInfo dir in source.GetDirectories())
+            {
+                dir.MoveTo(System.IO.Path.Combine(dest.FullName, dir.Name));
+            }
+            foreach (FileInfo file in source.GetFiles())
+            {
+                file.MoveTo(System.IO.Path.Combine(dest.FullName, file.Name));
+            }
+            source.Delete();
         }
         catch (Exception ex) when (ex.HResult < 0)
         {


### PR DESCRIPTION
There are cases when file managers or file explorers are used to access and modify save data files in the save data directory. This may cause the save data directory to be locked if those applications do not properly release or close the directory handle. Thus, when calls to `DirectorySaveDataFileSystem.DoCommit()` are made, which would invoke `LocalFileSystem.RenameDirInternal()` in turn, .NET would keep throwing an `IOException` with an `HResult` error code of 0x80070005 (`E_ACCESSDENIED`), indicating an Access Denied error.

This commit somehow fixes this issue by manually moving and renaming each subdirectory and file from the `source` directory to the `dest` directory before manually deleting the `source` directory. It seems that `DirectoryInfo` operations are known to be quite janky and sensitive to those directories being used by other processes on the machine. This proposed implementation is supposed to be equivalent to the previous implementation and it is tested to be working on Ryujinx.

This fixes Ryujinx/Ryujinx#5024.

Signed-off-by: James Raphael Tiovalen <jamestiotio@gmail.com>