### PR TITLE
[v2] Fix E_ACCESSDENIED error when renaming directory

### DIFF
--- a/src/LibHac/FsSystem/FileOperation.cs
+++ b/src/LibHac/FsSystem/FileOperation.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+using static Vanara.PInvoke.Shell32;
+
+namespace LibHac.FsSystem;
+
+public class FileOperation : IDisposable
+{
+    private bool disposed;
+    private IFileOperation fileOperation;
+
+    public FileOperation()
+    {
+        fileOperation = (IFileOperation)Activator.CreateInstance(typeof(CFileOperations));
+        fileOperation.SetOperationFlags(FILEOP_FLAGS.FOF_SILENT);
+    }
+
+    public void RenameItem(string source, string newName)
+    {
+        IShellItem sourceItem = SafeNativeMethods.CreateShellItem(source);
+
+        fileOperation.RenameItem(sourceItem, newName, null);
+    }
+
+    public bool PerformOperations()
+    {
+        try
+        {
+            fileOperation.PerformOperations();
+            return true;
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!disposed)
+        {
+            disposed = true;
+#pragma warning disable CA1416 // Validate platform compatibility
+            Marshal.FinalReleaseComObject(fileOperation);
+#pragma warning restore CA1416 // Validate platform compatibility
+        }
+    }
+}

--- a/src/LibHac/FsSystem/SafeNativeMethods.cs
+++ b/src/LibHac/FsSystem/SafeNativeMethods.cs
@@ -1,0 +1,14 @@
+using static Vanara.PInvoke.Shell32;
+
+namespace LibHac.FsSystem;
+
+public static class SafeNativeMethods
+{
+    public static IShellItem CreateShellItem(string path)
+    {
+        if (!Vanara.PInvoke.ShlwApi.PathFileExists(path))
+            return null;
+
+        return ShellUtil.GetShellItemForPath(path);
+    }
+}

--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -19,6 +19,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <!-- When doing a release build with a Git directory, SourceLink will set the SourceRoot needed for DeterministicSourcePaths -->
     <!-- Otherwise use a manually specified path -->
@@ -39,6 +40,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
+    <PackageReference Include="Vanara.PInvoke.Shell32" Version="3.4.15" />
+    <PackageReference Include="Vanara.PInvoke.ShlwApi" Version="3.4.15" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There are cases when file managers or file explorers are used to access and modify save data files in the save data directory. This may cause the save data directory to be locked if those applications do not properly release or close the directory handle. Thus, when calls to `DirectorySaveDataFileSystem.DoCommit()` are made, which would invoke `LocalFileSystem.RenameDirInternal()` in turn, .NET would keep throwing an `IOException` with an `HResult` error code of 0x80070005 (`E_ACCESSDENIED`), indicating an Access Denied error.

This commit fixes this issue by performing either of the following:

1. On Windows, manually rename the `source` directory to the `dest` directory via the P/Invoke API in `shobjidl_core.h`, which should be used by Windows Explorer in theory.
2. On other Unix-based operating systems, manually call the `rename` system call via the Mono framework to execute the renaming.

It seems that `DirectoryInfo` operations are known to be quite janky and sensitive to those directories being used by other processes on the machine. This proposed implementation is supposed to be equivalent to the previous implementation and it is tested to be working on Ryujinx. The operation remains atomic and hence, it should not leave the file system in an inconsistent state.

Signed-off-by: James Raphael Tiovalen <jamestiotio@gmail.com>