### PR TITLE
Misc bug fixes in BucketTree and when opening an NCA

### DIFF
--- a/src/LibHac/FsSystem/IndirectStorage.cs
+++ b/src/LibHac/FsSystem/IndirectStorage.cs
@@ -52,7 +52,7 @@ public class IndirectStorage : IStorage
 
     private struct ContinuousReadingEntry : BucketTree.IContinuousReadingEntry
     {
-        public int FragmentSizeMax => 1024 * 4;
+        public static int FragmentSizeMax => 1024 * 4;
 
 #pragma warning disable CS0649
         // This field will be read in by BucketTree.Visitor.ScanContinuousReading

--- a/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
@@ -299,8 +299,8 @@ public class Nca
 
         var treeHeader = new BucketTree.Header();
         info.EncryptionTreeHeader.CopyTo(SpanHelpers.AsByteSpan(ref treeHeader));
-        long nodeStorageSize = IndirectStorage.QueryNodeStorageSize(treeHeader.EntryCount);
-        long entryStorageSize = IndirectStorage.QueryEntryStorageSize(treeHeader.EntryCount);
+        long nodeStorageSize = AesCtrCounterExtendedStorage.QueryNodeStorageSize(treeHeader.EntryCount);
+        long entryStorageSize = AesCtrCounterExtendedStorage.QueryEntryStorageSize(treeHeader.EntryCount);
 
         var tableNodeStorage = new SubStorage(cachedBucketTreeData, 0, nodeStorageSize);
         var tableEntryStorage = new SubStorage(cachedBucketTreeData, nodeStorageSize, entryStorageSize);


### PR DESCRIPTION
Fixes a bug when opening an NCA where `IndirectStorage.QueryNodeStorageSize` was called instead of `AesCtrCounterExtendedStorage.QueryNodeStorageSize`. This bug didn't actually cause any incorrect functionality.

Fixes a bug in `BucketTree` where a call to `MoveNext` on a reader would not put the reader in an invalid state if reading the next entry from the entry storage was unsuccessful.