### PR TITLE
fix: Enable extra cli output for titlekeys (when using titlekey crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ NCA options:
   --basenca            Set Base NCA to use with update partitions.
   --basetitlekey       Specify single (encrypted) titlekey for the base NCA.
   --titlekey           Specify single (encrypted) titlekey.
+  --suppresskeys       Suppress output of decrypted keys.
 KIP1 options:
   --uncompressed <f>   Specify file path for saving uncompressed KIP1.
 RomFS options:

--- a/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
+++ b/src/LibHac/Tools/FsSystem/NcaUtils/Nca.cs
@@ -65,6 +65,18 @@ public class Nca
 
     private static readonly string[] KakNames = { "application", "ocean", "system" };
 
+    public byte[] GetEncryptedTitleKey()
+    {
+        var rightsId = new RightsId(Header.RightsId);
+
+        if (KeySet.ExternalKeySet.Get(rightsId, out AccessKey accessKey).IsFailure())
+        {
+            throw new MissingKeyException("Missing NCA title key.", rightsId.ToString(), KeyType.Title);
+        }
+        
+        return accessKey.Value.ToArray();
+    }
+
     public byte[] GetDecryptedTitleKey()
     {
         int keyRevision = Utilities.GetMasterKeyRevision(Header.KeyGeneration);

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -20,6 +20,7 @@ internal static class CliParser
         new CliOption("enablehash", 'h', 0, (o, _) => o.EnableHash = true),
         new CliOption("disablekeywarns", 0, (o, _) => o.DisableKeyWarns = true),
         new CliOption("enableallkeywarns", 0, (o, _) => o.EnableAllKeyWarns = true),
+        new CliOption("suppresskeys", 0, (o, _) => o.SuppressKeydataOutput = true),
         new CliOption("keyset", 'k', 1, (o, a) => o.Keyfile = a[0]),
         new CliOption("titlekeys", 1, (o, a) => o.TitleKeyFile = a[0]),
         new CliOption("consolekeys", 1, (o, a) => o.ConsoleKeyFile = a[0]),
@@ -294,6 +295,7 @@ internal static class CliParser
         sb.AppendLine("  --basenca            Set Base NCA to use with update partitions.");
         sb.AppendLine("  --basetitlekey       Specify single (encrypted) titlekey for the base NCA.");
         sb.AppendLine("  --titlekey           Specify single (encrypted) titlekey for the NCA.");
+        sb.AppendLine("  --suppresskeys       Suppress output of decrypted keys.");
         sb.AppendLine("KIP1 options:");
         sb.AppendLine("  --uncompressed <f>   Specify file path for saving uncompressed KIP1.");
         sb.AppendLine("RomFS options:");

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -18,6 +18,7 @@ internal class Options
     public bool EnableHash;
     public bool DisableKeyWarns;
     public bool EnableAllKeyWarns;
+    public bool SuppressKeydataOutput;
     public string Keyfile;
     public string TitleKeyFile;
     public string ConsoleKeyFile;

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -239,7 +239,7 @@ internal static class ProcessNca
                 nca.OpenEncryptedNca().WriteAllBytes(ctx.Options.CiphertextOut, ctx.Logger);
             }
 
-            if (!ctx.Options.ReadBench) ctx.Logger.LogMessage(ncaHolder.Print());
+            if (!ctx.Options.ReadBench) ctx.Logger.LogMessage(ncaHolder.Print(ctx.Options));
 
             IStorage OpenStorage(int index)
             {
@@ -309,7 +309,7 @@ internal static class ProcessNca
         return keyGeneration - 1;
     }
 
-    private static string Print(this NcaHolder ncaHolder)
+    private static string Print(this NcaHolder ncaHolder, Options options)
     {
         Nca nca = ncaHolder.Nca;
         int masterKey = GetMasterKeyRevisionFromKeyGeneration(nca.Header.KeyGeneration);
@@ -347,7 +347,11 @@ internal static class ProcessNca
         {
             PrintItem(sb, colLen, "Rights ID:", nca.Header.RightsId.ToArray());
             PrintItem(sb, colLen, "Titlekey (Encrypted):", nca.GetEncryptedTitleKey());
-            PrintItem(sb, colLen, "Titlekey (Decrypted):", nca.GetDecryptedTitleKey());
+
+            if (!options.SuppressKeydataOutput)
+            {
+                PrintItem(sb, colLen, "Titlekey (Decrypted):", nca.GetDecryptedTitleKey());
+            }
         }
         else
         {
@@ -367,10 +371,13 @@ internal static class ProcessNca
                 sb.AppendLine("Key Area (Encrypted):");
                 PrintItem(sb, colLen, "Key (RSA-OAEP Encrypted):", nca.Header.GetKeyArea().ToArray());
 
-                sb.AppendLine("Key Area (Decrypted):");
-                for (int i = 0; i < 2; i++)
+                if (!options.SuppressKeydataOutput)
                 {
-                    PrintItem(sb, colLen, $"    Key {i} (Decrypted):", nca.GetDecryptedKey(i));
+                    sb.AppendLine("Key Area (Decrypted):");
+                    for (int i = 0; i < 2; i++)
+                    {
+                        PrintItem(sb, colLen, $"    Key {i} (Decrypted):", nca.GetDecryptedKey(i));
+                    }
                 }
             }
             else if (version == NcaVersion.Nca0FixedKey)
@@ -392,10 +399,13 @@ internal static class ProcessNca
                     PrintItem(sb, colLen, $"    Key {i} (Encrypted):", nca.Header.GetEncryptedKey(i).ToArray());
                 }
 
-                sb.AppendLine("Key Area (Decrypted):");
-                for (int i = 0; i < keyCount; i++)
+                if (!options.SuppressKeydataOutput)
                 {
-                    PrintItem(sb, colLen, $"    Key {i} (Decrypted):", nca.GetDecryptedKey(i));
+                    sb.AppendLine("Key Area (Decrypted):");
+                    for (int i = 0; i < keyCount; i++)
+                    {
+                        PrintItem(sb, colLen, $"    Key {i} (Decrypted):", nca.GetDecryptedKey(i));
+                    }
                 }
             }
         }

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -346,6 +346,8 @@ internal static class ProcessNca
         if (nca.Header.HasRightsId)
         {
             PrintItem(sb, colLen, "Rights ID:", nca.Header.RightsId.ToArray());
+            PrintItem(sb, colLen, "Titlekey (Encrypted):", nca.GetEncryptedTitleKey());
+            PrintItem(sb, colLen, "Titlekey (Decrypted):", nca.GetDecryptedTitleKey());
         }
         else
         {


### PR DESCRIPTION
Replicating `hactool` output as part of request in #278 

When using titlekey crypto we print both encrypted and decrypted titlekeys. This is useful for scripting/preservation efforts.

![image](https://github.com/Thealexbarney/LibHac/assets/221695/e67ed14f-7742-4ed9-b65c-0841368e667a)
