### PR TITLE
feat: Allow user to supply a titlekey on the command-line when processing NCAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NCA options:
   --romfsdir <dir>     Specify RomFS directory path.
   --listromfs          List files in RomFS.
   --basenca            Set Base NCA to use with update partitions.
+  --basetitlekey       Specify single (encrypted) titlekey for the base NCA.
   --titlekey           Specify single (encrypted) titlekey.
 KIP1 options:
   --uncompressed <f>   Specify file path for saving uncompressed KIP1.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NCA options:
   --romfsdir <dir>     Specify RomFS directory path.
   --listromfs          List files in RomFS.
   --basenca            Set Base NCA to use with update partitions.
+  --titlekey           Specify single (encrypted) titlekey.
 KIP1 options:
   --uncompressed <f>   Specify file path for saving uncompressed KIP1.
 RomFS options:

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -217,15 +217,17 @@ internal static class CliParser
         return id;
     }
 
-    private static string ParseTitleKey(Options options, string input)
+    private static byte[] ParseTitleKey(Options options, string input)
     {
-        if (input.Length != 32)
+        byte[] key = new byte[32];
+        
+        if (input.Length != 32 || !StringUtils.TryFromHexString(input, key))
         {
             options.ParseErrorMessage ??= "TitleKey must be 32 hex characters long";
             return default;
         }
 
-        return input.ToUpperInvariant();
+        return key;
     }
 
     private static double ParseDouble(Options options, string input)

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -289,7 +289,7 @@ internal static class CliParser
         sb.AppendLine("  --romfsdir <dir>     Specify RomFS directory path.");
         sb.AppendLine("  --listromfs          List files in RomFS.");
         sb.AppendLine("  --basenca            Set Base NCA to use with update partitions.");
-        sb.AppendLine("  --titlekey           Specify singular (encrypted) titlekey.");
+        sb.AppendLine("  --titlekey           Specify single (encrypted) titlekey.");
         sb.AppendLine("KIP1 options:");
         sb.AppendLine("  --uncompressed <f>   Specify file path for saving uncompressed KIP1.");
         sb.AppendLine("RomFS options:");

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using LibHac.Util;
 
 namespace hactoolnet;
 
@@ -49,6 +50,7 @@ internal static class CliParser
         new CliOption("sdseed", 1, (o, a) => o.SdSeed = a[0]),
         new CliOption("sdpath", 1, (o, a) => o.SdPath = a[0]),
         new CliOption("basenca", 1, (o, a) => o.BaseNca = a[0]),
+        new CliOption("titlekey", 1, (o, a) => o.TitleKey = ParseTitleKey(o, a[0])),
         new CliOption("basefile", 1, (o, a) => o.BaseFile = a[0]),
         new CliOption("rootdir", 1, (o, a) => o.RootDir = a[0]),
         new CliOption("updatedir", 1, (o, a) => o.UpdateDir = a[0]),
@@ -214,6 +216,17 @@ internal static class CliParser
         return id;
     }
 
+    private static string ParseTitleKey(Options options, string input)
+    {
+        if (input.Length != 32)
+        {
+            options.ParseErrorMessage ??= "TitleKey must be 32 hex characters long";
+            return default;
+        }
+
+        return input.ToUpperInvariant();
+    }
+
     private static double ParseDouble(Options options, string input)
     {
         if (!double.TryParse(input, out double value))
@@ -276,6 +289,7 @@ internal static class CliParser
         sb.AppendLine("  --romfsdir <dir>     Specify RomFS directory path.");
         sb.AppendLine("  --listromfs          List files in RomFS.");
         sb.AppendLine("  --basenca            Set Base NCA to use with update partitions.");
+        sb.AppendLine("  --titlekey           Specify singular (encrypted) titlekey.");
         sb.AppendLine("KIP1 options:");
         sb.AppendLine("  --uncompressed <f>   Specify file path for saving uncompressed KIP1.");
         sb.AppendLine("RomFS options:");

--- a/src/hactoolnet/CliParser.cs
+++ b/src/hactoolnet/CliParser.cs
@@ -50,6 +50,7 @@ internal static class CliParser
         new CliOption("sdseed", 1, (o, a) => o.SdSeed = a[0]),
         new CliOption("sdpath", 1, (o, a) => o.SdPath = a[0]),
         new CliOption("basenca", 1, (o, a) => o.BaseNca = a[0]),
+        new CliOption("basetitlekey", 1, (o, a) => o.BaseTitleKey = ParseTitleKey(o, a[0])),
         new CliOption("titlekey", 1, (o, a) => o.TitleKey = ParseTitleKey(o, a[0])),
         new CliOption("basefile", 1, (o, a) => o.BaseFile = a[0]),
         new CliOption("rootdir", 1, (o, a) => o.RootDir = a[0]),
@@ -289,7 +290,8 @@ internal static class CliParser
         sb.AppendLine("  --romfsdir <dir>     Specify RomFS directory path.");
         sb.AppendLine("  --listromfs          List files in RomFS.");
         sb.AppendLine("  --basenca            Set Base NCA to use with update partitions.");
-        sb.AppendLine("  --titlekey           Specify single (encrypted) titlekey.");
+        sb.AppendLine("  --basetitlekey       Specify single (encrypted) titlekey for the base NCA.");
+        sb.AppendLine("  --titlekey           Specify single (encrypted) titlekey for the NCA.");
         sb.AppendLine("KIP1 options:");
         sb.AppendLine("  --uncompressed <f>   Specify file path for saving uncompressed KIP1.");
         sb.AppendLine("RomFS options:");

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -63,6 +63,7 @@ internal class Options
     public bool ExtractIni1;
     public ulong TitleId;
     public string TitleKey;
+    public string BaseTitleKey;
     public string BenchType;
     public double CpuFrequencyGhz;
 

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -62,8 +62,8 @@ internal class Options
     public bool BuildHfs;
     public bool ExtractIni1;
     public ulong TitleId;
-    public string TitleKey;
-    public string BaseTitleKey;
+    public byte[] TitleKey;
+    public byte[] BaseTitleKey;
     public string BenchType;
     public double CpuFrequencyGhz;
 

--- a/src/hactoolnet/Options.cs
+++ b/src/hactoolnet/Options.cs
@@ -62,6 +62,7 @@ internal class Options
     public bool BuildHfs;
     public bool ExtractIni1;
     public ulong TitleId;
+    public string TitleKey;
     public string BenchType;
     public double CpuFrequencyGhz;
 

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -6,10 +6,12 @@ using LibHac.Fs;
 using LibHac.Fs.Fsa;
 using LibHac.Fs.Impl;
 using LibHac.FsSystem;
+using LibHac.Spl;
 using LibHac.Tools.Fs;
 using LibHac.Tools.FsSystem;
 using LibHac.Tools.FsSystem.NcaUtils;
 using LibHac.Tools.Npdm;
+using LibHac.Util;
 using static hactoolnet.Print;
 using NcaFsHeader = LibHac.Tools.FsSystem.NcaUtils.NcaFsHeader;
 
@@ -23,6 +25,20 @@ internal static class ProcessNca
         {
             var nca = new Nca(ctx.KeySet, file);
             Nca baseNca = null;
+
+            if(!string.IsNullOrEmpty(ctx.Options.TitleKey) && nca.Header.HasRightsId)
+            {
+                var titleKey = new AccessKey();
+                var rightsId = new RightsId(nca.Header.RightsId);
+
+                if (!StringUtils.TryFromHexString(ctx.Options.TitleKey, SpanHelpers.AsByteSpan(ref titleKey)))
+                {
+                    ctx.Logger.LogMessage($"Invalid title key \"{ctx.Options.TitleKey}\"");
+                    return;
+                }
+
+                ctx.KeySet.ExternalKeySet.Add(rightsId, titleKey);
+            }
 
             var ncaHolder = new NcaHolder { Nca = nca };
 

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -277,19 +277,20 @@ internal static class ProcessNca
     private static bool TryAddTitleKey(KeySet keySet, string cliTitleKey, Span<byte> rightsId)
     {
         var titleKey = new AccessKey();
+        var rId = new RightsId(rightsId);
 
         if (!StringUtils.TryFromHexString(cliTitleKey, SpanHelpers.AsByteSpan(ref titleKey)))
         {
             return false;
         }
 
-        var rId = new RightsId(rightsId);
-
-        if(!keySet.ExternalKeySet.Contains(rId))
+        if (keySet.ExternalKeySet.Contains(rId))
         {
-            keySet.ExternalKeySet.Add(rId, titleKey);
+            keySet.ExternalKeySet.Remove(rId);
         }
 
+        keySet.ExternalKeySet.Add(rId, titleKey);
+        
         return true;
     }
 

--- a/src/hactoolnet/ProcessNca.cs
+++ b/src/hactoolnet/ProcessNca.cs
@@ -283,7 +283,13 @@ internal static class ProcessNca
             return false;
         }
 
-        keySet.ExternalKeySet.Add(new RightsId(rightsId), titleKey);
+        var rId = new RightsId(rightsId);
+
+        if(!keySet.ExternalKeySet.Contains(rId))
+        {
+            keySet.ExternalKeySet.Add(rId, titleKey);
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Another `hactool` feature. Adding the ability to supply a single (encrypted) titlekey when processing a NCA file. This is useful in scripting situations where you dont have the titlekey in a file as it may be being supplied from elsewhere.

Adds: 
* `--titlekey` - A single 32 char hex string
* `--basetitlekey` - Allows you to supply the titlekey for the base NCA as well.

Addresses some of #279 

Note: If the key is already present in the `title.keys` collection supplying via `--titlekey` will override this.