### PR TITLE
Add license file to artifacts

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -48,6 +48,7 @@ partial class Build : NukeBuild
     AbsolutePath CliNativeExe => CliNativeDir / $"hactoolnet{NativeProgramExtension}";
     AbsolutePath CliCoreZip => ArtifactsDirectory / $"hactoolnet-{VersionString}-netcore.zip";
     AbsolutePath CliNativeZip => ArtifactsDirectory / $"hactoolnet-{VersionString}-{HostOsName}.zip";
+    AbsolutePath LicenseFile => RootDirectory / "LICENSE";
 
     Project LibHacProject => _solution.GetProject("LibHac").NotNull();
     Project LibHacTestProject => _solution.GetProject("LibHac.Tests").NotNull();
@@ -288,6 +289,7 @@ partial class Build : NukeBuild
         {
             string[] namesCore = Directory.EnumerateFiles(CliCoreDir, "*.json")
                 .Concat(Directory.EnumerateFiles(CliCoreDir, "*.dll"))
+                .Append((string)LicenseFile)
                 .ToArray();
 
             ArtifactsDirectory.CreateDirectory();
@@ -395,7 +397,7 @@ partial class Build : NukeBuild
 
         ArtifactsDirectory.CreateOrCleanDirectory();
 
-        ZipFile(CliNativeZip, CliNativeExe, $"hactoolnet{NativeProgramExtension}", CommitTime);
+        ZipFiles(CliNativeZip, [CliNativeExe, LicenseFile], CommitTime);
         Serilog.Log.Debug($"Created {CliNativeZip}");
         Serilog.Log.Debug($"Created {CliNativeZip}");
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -48,7 +48,6 @@ partial class Build : NukeBuild
     AbsolutePath CliNativeExe => CliNativeDir / $"hactoolnet{NativeProgramExtension}";
     AbsolutePath CliCoreZip => ArtifactsDirectory / $"hactoolnet-{VersionString}-netcore.zip";
     AbsolutePath CliNativeZip => ArtifactsDirectory / $"hactoolnet-{VersionString}-{HostOsName}.zip";
-    AbsolutePath LicenseFile => RootDirectory / "LICENSE";
 
     Project LibHacProject => _solution.GetProject("LibHac").NotNull();
     Project LibHacTestProject => _solution.GetProject("LibHac.Tests").NotNull();
@@ -289,7 +288,6 @@ partial class Build : NukeBuild
         {
             string[] namesCore = Directory.EnumerateFiles(CliCoreDir, "*.json")
                 .Concat(Directory.EnumerateFiles(CliCoreDir, "*.dll"))
-                .Append((string)LicenseFile)
                 .ToArray();
 
             ArtifactsDirectory.CreateDirectory();
@@ -397,7 +395,7 @@ partial class Build : NukeBuild
 
         ArtifactsDirectory.CreateOrCleanDirectory();
 
-        ZipFiles(CliNativeZip, [CliNativeExe, LicenseFile], CommitTime);
+        ZipFile(CliNativeZip, CliNativeExe, $"hactoolnet{NativeProgramExtension}", CommitTime);
         Serilog.Log.Debug($"Created {CliNativeZip}");
         Serilog.Log.Debug($"Created {CliNativeZip}");
 

--- a/src/LibHac/LibHac.csproj
+++ b/src/LibHac/LibHac.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <Compile Condition="Exists('Common\ResultNameResolver.Generated.cs')" Remove="Common\ResultNameResolver.Archive.cs" />
     <Compile Condition="Exists('Common\Keys\DefaultKeySet.Generated.cs')" Remove="Common\Keys\DefaultKeySet.Empty.cs" />
   </ItemGroup>


### PR DESCRIPTION
The license file should be present in the NuGet package, since the MIT license requires that it gets included in all copies.

~~I'm not sure if you like including it for the other release files as well, but I included them for now.~~