### PR TITLE
Fix reading tickets from a Sha256PartitionFileSystem

### DIFF
--- a/src/LibHac/Tools/FsSystem/NxFileStream.cs
+++ b/src/LibHac/Tools/FsSystem/NxFileStream.cs
@@ -25,7 +25,7 @@ public class NxFileStream : Stream
 
     public override int Read(byte[] buffer, int offset, int count)
     {
-        BaseFile.Read(out long bytesRead, Position, buffer.AsSpan(offset, count));
+        BaseFile.Read(out long bytesRead, Position, buffer.AsSpan(offset, count)).ThrowIfFailure();
 
         Position += bytesRead;
         return (int)bytesRead;
@@ -33,14 +33,14 @@ public class NxFileStream : Stream
 
     public override void Write(byte[] buffer, int offset, int count)
     {
-        BaseFile.Write(Position, buffer.AsSpan(offset, count));
+        BaseFile.Write(Position, buffer.AsSpan(offset, count)).ThrowIfFailure();
 
         Position += count;
     }
 
     public override void Flush()
     {
-        BaseFile.Flush();
+        BaseFile.Flush().ThrowIfFailure();
     }
 
     public override long Seek(long offset, SeekOrigin origin)


### PR DESCRIPTION
Reading files from a `Sha256PartitionFileSystem` has the restriction where you can't start a read in the middle of the hashed region of the file (usually the first 0x200 bytes) and end the read past the end of the hashed region. This was happening for ticket files, so we'll fix that to make sure those kinds of reads don't happen

Fixes #288 